### PR TITLE
Rewrite chronological HIJ report with full data

### DIFF
--- a/informe_cronologico.html
+++ b/informe_cronologico.html
@@ -1,0 +1,361 @@
+<!doctype html>
+<html lang="es">
+<head>
+<meta charset="utf-8">
+<title>Informe cronológico H/I/J (1995-2025)</title>
+<style>
+  :root{color-scheme:light;background:#f5f6fb}
+  *{box-sizing:border-box}
+  body{font-family:'Segoe UI',Roboto,Arial,sans-serif;margin:28px auto;max-width:1080px;line-height:1.65;color:#1f2933;background:linear-gradient(180deg,#f5f6fb 0%,#f8f9fc 60%,#fefefe 100%)}
+  header{margin-bottom:28px}
+  h1{margin:0;font-size:32px;color:#0b2545}
+  .lead{color:#52606d;margin:10px 0 18px 0;max-width:900px}
+  h2{margin-top:40px;margin-bottom:14px;color:#0b2545;font-size:26px}
+  h3{margin-top:24px;margin-bottom:10px;color:#183153;font-size:20px}
+  p{margin:0 0 16px 0}
+  ul{padding-left:20px;margin:0 0 18px 0}
+  li{margin-bottom:8px}
+  code{background:#eef2ff;padding:1px 5px;border-radius:6px;font-size:0.92em;color:#312e81}
+  .cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:16px;margin:24px 0 8px 0}
+  .card{background:#fff;border:1px solid #dfe3f0;border-radius:18px;padding:18px 20px;box-shadow:0 18px 40px -30px rgba(15,23,42,.55);display:flex;flex-direction:column;gap:10px}
+  .card .kicker{text-transform:uppercase;font-size:13px;letter-spacing:.06em;color:#64748b;font-weight:600}
+  .card .figure{font-size:26px;font-weight:700;color:#0b2545}
+  .card .caption{color:#475569;font-size:14px}
+  .card .tiny{font-size:12px;color:#6c7a89}
+  .guide{background:#fff;border:1px solid #dfe3f0;border-radius:16px;padding:20px 22px;box-shadow:0 10px 24px -24px rgba(15,23,42,.55)}
+  .guide ul{margin:0;padding-left:20px}
+  .timeline{position:relative;margin:26px 0 16px 0;padding-left:26px}
+  .timeline:before{content:"";position:absolute;left:10px;top:4px;bottom:4px;width:2px;background:#cbd5f5}
+  .t-item{position:relative;margin-bottom:22px;padding-left:12px}
+  .t-item:last-child{margin-bottom:0}
+  .t-item:before{content:"";position:absolute;left:-20px;top:3px;width:14px;height:14px;border-radius:50%;background:#1d4ed8;box-shadow:0 0 0 4px rgba(59,130,246,.18)}
+  .t-date{font-weight:600;color:#0b2545}
+  .t-body{color:#374151}
+  .bar-chart{display:flex;flex-direction:column;gap:12px;margin:18px 0 12px 0}
+  .bar{display:flex;align-items:center;gap:12px}
+  .bar-label{flex:0 0 150px;font-weight:600;color:#1f2a44}
+  .bar-track{flex:1;height:16px;border-radius:999px;background:#e7ecff;overflow:hidden;position:relative}
+  .bar-fill{height:100%;border-radius:999px;background:linear-gradient(90deg,#4f46e5,#60a5fa)}
+  .bar-value{flex:0 0 150px;text-align:right;font-variant-numeric:tabular-nums;color:#334155}
+  .tiny{font-size:12px;color:#6b7280}
+  .unit-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:18px;margin:14px 0 12px 0}
+  .unit-card{background:#fff;border:1px solid #dfe3f0;border-radius:18px;padding:18px 20px;box-shadow:0 18px 40px -30px rgba(15,23,42,.55)}
+  .unit-card header{margin:0 0 12px 0}
+  .unit-card h3{margin:0;font-size:19px;color:#0b2545}
+  .unit-card p{margin:0 0 12px 0;color:#334155}
+  .legend-list{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:14px}
+  .legend-item{border-left:4px solid #c7d2fe;padding-left:12px}
+  .legend-item strong{color:#1e3a8a}
+  .legend-meta{font-size:13px;color:#475569;margin:4px 0}
+  .legend-note{font-size:13px;color:#334155}
+  table{width:100%;border-collapse:collapse;background:#fff;border-radius:16px;overflow:hidden;box-shadow:0 16px 36px -32px rgba(15,23,42,.55);margin-bottom:18px}
+  th,td{border:1px solid #e2e8f0;padding:10px 12px;text-align:left}
+  th{background:#eff4ff;color:#1e3a8a;font-weight:600}
+  td.num{text-align:right;font-variant-numeric:tabular-nums}
+  .callout{background:#f1f5f9;border-left:4px solid #2563eb;padding:16px 18px;border-radius:14px;color:#1e293b;margin:18px 0}
+  details{background:#fff;border:1px solid #dfe3f0;border-radius:16px;padding:16px 18px;box-shadow:0 12px 28px -28px rgba(15,23,42,.55);margin-bottom:16px}
+  summary{font-weight:600;color:#0f172a;cursor:pointer}
+  .iframe-wrapper{margin-top:12px;border:1px solid #cbd5f5;border-radius:14px;overflow:hidden}
+  .iframe-wrapper iframe{width:100%;height:420px;border:0;background:#fff}
+  .iframe-note{font-size:12px;color:#64748b;margin-top:8px}
+  footer{margin-top:40px;font-size:12px;color:#64748b}
+  @media(max-width:720px){
+    body{margin:18px}
+    .bar-label{flex:0 0 120px}
+    .bar-value{flex:0 0 120px}
+    .iframe-wrapper iframe{height:360px}
+  }
+</style>
+</head>
+<body>
+<header>
+  <h1>Informe cronológico de la consolidación H · I · J</h1>
+  <p class="lead">Resumen narrado para toda la familia: desde el primer archivo fechado el <strong>01/01/1995</strong> hasta la consolidación final del <strong>23/09/2025</strong>. Los datos provienen del inventario <code>index_by_hash.csv</code>, los listados interactivos y los registros de movimiento del proyecto HIJ.</p>
+</header>
+
+<section class="cards">
+  <article class="card">
+    <div class="kicker">Huella analizada</div>
+    <div class="figure">3,20&nbsp;TB</div>
+    <div class="caption">60.639 archivos (3.282,50&nbsp;GB) revisados entre 1995 y 2025.</div>
+  </article>
+  <article class="card">
+    <div class="kicker">Duplicados localizados</div>
+    <div class="figure">46.494 ficheros</div>
+    <div class="caption">Son el 76,7&nbsp;% del total y ocupan 995,24&nbsp;GB potencialmente recuperables.</div>
+  </article>
+  <article class="card">
+    <div class="kicker">Material en cuarentena</div>
+    <div class="figure">59.420 ítems</div>
+    <div class="caption">1,12&nbsp;TB resguardados en carpetas <code>_quarantine</code> para revisar con calma.</div>
+  </article>
+  <article class="card">
+    <div class="kicker">Última consolidación</div>
+    <div class="figure">23/09/2025</div>
+    <div class="caption">El “Índice por hash” registra 60.639 entradas para garantizar la trazabilidad.</div>
+  </article>
+</section>
+
+<section class="guide">
+  <h2 style="margin-top:0">Cómo leer este informe</h2>
+  <ul>
+    <li><strong>Gráficos sencillos.</strong> Las barras representan proporciones reales calculadas a partir del inventario. Cuanto más larga sea la barra, más espacio ocupa la etapa o el tipo de archivo.</li>
+    <li><strong>Lenguaje llano.</strong> Cada etapa incluye contexto para identificar momentos familiares (cámaras digitales, documentales, volcados de discos…).</li>
+    <li><strong>Seguimiento transparente.</strong> Los anexos enlazan con los listados interactivos para explorar carpetas completas sin salir del informe.</li>
+  </ul>
+</section>
+
+<h2>Cronología del archivo familiar (1995-2025)</h2>
+<div class="timeline">
+  <div class="t-item">
+    <div class="t-date">1995-2002 · Primeras digitalizaciones</div>
+    <div class="t-body">1.698 archivos (5,14&nbsp;GB) inauguran la colección. Son escaneos y documentos ligeros que marcan el salto del papel al ordenador.</div>
+  </div>
+  <div class="t-item">
+    <div class="t-date">2003-2005 · Auge de las cámaras compactas</div>
+    <div class="t-body">21.053 elementos (74,17&nbsp;GB) recogen vacaciones, excursiones y celebraciones familiares. Aquí aparecen ya varias copias del mismo álbum.</div>
+  </div>
+  <div class="t-item">
+    <div class="t-date">2006-2009 · Etapa de mayor actividad</div>
+    <div class="t-body">25.416 ficheros (201,59&nbsp;GB) alimentan el disco común. Muchas carpetas se replican entre unidades, lo que obligó a crear la cuarentena años después.</div>
+  </div>
+  <div class="t-item">
+    <div class="t-date">2010-2012 · Llegan los vídeos Full&nbsp;HD</div>
+    <div class="t-body">7.343 archivos pero 1.209,27&nbsp;GB. Los clips <code>.m2ts</code> y <code>.mp4</code> multiplican el peso y explican buena parte de los duplicados.</div>
+  </div>
+  <div class="t-item">
+    <div class="t-date">2013-2014 · Grandes proyectos audiovisuales</div>
+    <div class="t-body">1.757 archivos ocupan 1.585,56&nbsp;GB. Son montajes largos y versiones intermedias que acabaron duplicadas en varios discos.</div>
+  </div>
+  <div class="t-item">
+    <div class="t-date">2015-2016 · Últimas sesiones</div>
+    <div class="t-body">151 ficheros (165,16&nbsp;GB) proceden de cámaras réflex y volcados puntuales antes de un parón largo.</div>
+  </div>
+  <div class="t-item">
+    <div class="t-date">2025 · Reactivación y limpieza</div>
+    <div class="t-body">3.221 archivos recientes (41,61&nbsp;GB) y los listados técnicos (<code>session_kpis.csv</code>, <code>moves_log.csv</code>) documentan la puesta en orden final.</div>
+  </div>
+</div>
+
+<h3>Evolución del volumen por periodo</h3>
+<div class="bar-chart">
+  <div class="bar"><div class="bar-label">1995-2002</div><div class="bar-track"><div class="bar-fill" style="width:0.3%"></div></div><div class="bar-value">1.698 archivos · 5,14&nbsp;GB</div></div>
+  <div class="bar"><div class="bar-label">2003-2005</div><div class="bar-track"><div class="bar-fill" style="width:4.7%"></div></div><div class="bar-value">21.053 archivos · 74,17&nbsp;GB</div></div>
+  <div class="bar"><div class="bar-label">2006-2009</div><div class="bar-track"><div class="bar-fill" style="width:12.7%"></div></div><div class="bar-value">25.416 archivos · 201,59&nbsp;GB</div></div>
+  <div class="bar"><div class="bar-label">2010-2012</div><div class="bar-track"><div class="bar-fill" style="width:76.3%"></div></div><div class="bar-value">7.343 archivos · 1.209,27&nbsp;GB</div></div>
+  <div class="bar"><div class="bar-label">2013-2014</div><div class="bar-track"><div class="bar-fill" style="width:100%"></div></div><div class="bar-value">1.757 archivos · 1.585,56&nbsp;GB</div></div>
+  <div class="bar"><div class="bar-label">2015-2016</div><div class="bar-track"><div class="bar-fill" style="width:10.4%"></div></div><div class="bar-value">151 archivos · 165,16&nbsp;GB</div></div>
+  <div class="bar"><div class="bar-label">2025</div><div class="bar-track"><div class="bar-fill" style="width:2.6%"></div></div><div class="bar-value">3.221 archivos · 41,61&nbsp;GB</div></div>
+</div>
+<p class="tiny">Fuente: agregación de fechas de última modificación en <code>index_by_hash.csv</code>. El pico de 2013-2014 concentra los proyectos que después se duplicaron entre discos.</p>
+
+<h2>Duplicados y espacio recuperable</h2>
+<p>El inventario identifica <strong>46.494 copias repetidas</strong>, que equivalen al <strong>76,7&nbsp;%</strong> de todos los ficheros y consumen <strong>995,24&nbsp;GB</strong>. Al conservar una sola copia por cada huella digital (hash) se recupera hasta un 30&nbsp;% del espacio total.</p>
+
+<h3>Duplicados por tipo de archivo (espacio desaprovechado)</h3>
+<div class="bar-chart">
+  <div class="bar"><div class="bar-label">.m2ts</div><div class="bar-track"><div class="bar-fill" style="width:100%"></div></div><div class="bar-value">624,88&nbsp;GB · 62,8&nbsp;%</div></div>
+  <div class="bar"><div class="bar-label">.mpg</div><div class="bar-track"><div class="bar-fill" style="width:43.1%"></div></div><div class="bar-value">269,41&nbsp;GB · 27,1&nbsp;%</div></div>
+  <div class="bar"><div class="bar-label">.jpg</div><div class="bar-track"><div class="bar-fill" style="width:8.3%"></div></div><div class="bar-value">51,69&nbsp;GB · 5,2&nbsp;%</div></div>
+  <div class="bar"><div class="bar-label">.avi</div><div class="bar-track"><div class="bar-fill" style="width:3.6%"></div></div><div class="bar-value">22,38&nbsp;GB · 2,2&nbsp;%</div></div>
+  <div class="bar"><div class="bar-label">.mp4</div><div class="bar-track"><div class="bar-fill" style="width:3.0%"></div></div><div class="bar-value">18,84&nbsp;GB · 1,9&nbsp;%</div></div>
+  <div class="bar"><div class="bar-label">.tif</div><div class="bar-track"><div class="bar-fill" style="width:0.3%"></div></div><div class="bar-value">2,15&nbsp;GB · 0,2&nbsp;%</div></div>
+  <div class="bar"><div class="bar-label">.bmp</div><div class="bar-track"><div class="bar-fill" style="width:0.2%"></div></div><div class="bar-value">1,33&nbsp;GB · 0,1&nbsp;%</div></div>
+  <div class="bar"><div class="bar-label">.dcr</div><div class="bar-track"><div class="bar-fill" style="width:0.2%"></div></div><div class="bar-value">1,25&nbsp;GB · 0,1&nbsp;%</div></div>
+</div>
+<p class="tiny">Cálculo: agrupación por hash en <code>index_by_hash.csv</code> y comparación de tamaños para estimar el espacio duplicado que se puede liberar manteniendo una copia por grupo.</p>
+
+<h2>Radiografía por unidad</h2>
+<p>Así queda el reparto del contenido tras la consolidación. La unidad <strong>I:</strong> concentra el 56,4&nbsp;% del tamaño total, <strong>H:</strong> actúa como repositorio maestro (33,4&nbsp;%) y <strong>J:</strong> mantiene copias de apoyo (10,2&nbsp;%).</p>
+
+<h3>Distribución de espacio por unidad</h3>
+<div class="bar-chart">
+  <div class="bar"><div class="bar-label">Unidad I:</div><div class="bar-track"><div class="bar-fill" style="width:100%"></div></div><div class="bar-value">1,81&nbsp;TB · 5.080 archivos</div></div>
+  <div class="bar"><div class="bar-label">Unidad H:</div><div class="bar-track"><div class="bar-fill" style="width:59.2%"></div></div><div class="bar-value">1,07&nbsp;TB · 29.990 archivos</div></div>
+  <div class="bar"><div class="bar-label">Unidad J:</div><div class="bar-track"><div class="bar-fill" style="width:18.0%"></div></div><div class="bar-value">0,33&nbsp;TB · 25.569 archivos</div></div>
+</div>
+
+<div class="unit-grid">
+  <section class="unit-card">
+    <header><h3>Disco H:</h3></header>
+    <p>Repositorio maestro donde conviven el material final y la cuarentena común. Representa el 33,4&nbsp;% del tamaño total.</p>
+    <ul class="legend-list">
+      <li class="legend-item">
+        <strong>_quarantine_from_HIJ</strong>
+        <div class="legend-meta">28.365 archivos · 646,69&nbsp;GB (59,0&nbsp;% del disco H:)</div>
+        <div class="legend-note">Caja fuerte de duplicados y material pendiente de revisar antes de borrar nada.</div>
+      </li>
+      <li class="legend-item">
+        <strong>Media_Final</strong>
+        <div class="legend-meta">193 archivos · 350,41&nbsp;GB (32,0&nbsp;%)</div>
+        <div class="legend-note">Colección definitiva lista para compartir con la familia.</div>
+      </li>
+      <li class="legend-item">
+        <strong>offload</strong>
+        <div class="legend-meta">1.167 archivos · 94,65&nbsp;GB (8,6&nbsp;%)</div>
+        <div class="legend-note">Zona de trabajo donde se agruparon carpetas antes de moverlas a su destino final.</div>
+      </li>
+      <li class="legend-item">
+        <strong>_quarantine</strong>
+        <div class="legend-meta">1 archivo · 4,16&nbsp;GB</div>
+        <div class="legend-note">Imagen de respaldo del disco I: por si fuera necesario reconstruirlo.</div>
+      </li>
+      <li class="legend-item">
+        <strong>VIDEOS FAMILIA</strong>
+        <div class="legend-meta">4 archivos · 0,20&nbsp;GB</div>
+        <div class="legend-note">Selección de clips familiares de referencia lista para copiar.</div>
+      </li>
+    </ul>
+  </section>
+  <section class="unit-card">
+    <header><h3>Disco I:</h3></header>
+    <p>Biblioteca audiovisual principal. Aporta más de la mitad del espacio total con películas y documentales.</p>
+    <ul class="legend-list">
+      <li class="legend-item">
+        <strong>PELICULAS</strong>
+        <div class="legend-meta">242 archivos · 954,05&nbsp;GB (51,5&nbsp;% de I:)</div>
+        <div class="legend-note">Largometrajes y digitalizaciones familiares listos para reproducirse.</div>
+      </li>
+      <li class="legend-item">
+        <strong>VIDEOS CIENCIA Y TECNOLOGIA</strong>
+        <div class="legend-meta">387 archivos · 668,91&nbsp;GB (36,1&nbsp;%)</div>
+        <div class="legend-note">Documentales especializados que se mantuvieron juntos para facilitar su consulta.</div>
+      </li>
+      <li class="legend-item">
+        <strong>_quarantine</strong>
+        <div class="legend-meta">4.401 archivos · 98,97&nbsp;GB (5,3&nbsp;%)</div>
+        <div class="legend-note">Duplicados detectados en I: a la espera de decidir qué conservar.</div>
+      </li>
+      <li class="legend-item">
+        <strong>FAMILIA</strong>
+        <div class="legend-meta">48 archivos · 97,41&nbsp;GB (5,3&nbsp;%)</div>
+        <div class="legend-note">Vídeos caseros escogidos para tenerlos siempre a mano.</div>
+      </li>
+      <li class="legend-item">
+        <strong>EL JARDIN DE LOS SUEÑOS.avi</strong>
+        <div class="legend-meta">1 archivo · 31,88&nbsp;GB</div>
+        <div class="legend-note">Película muy pesada pendiente de decidir si se comprime o se mueve al área principal.</div>
+      </li>
+    </ul>
+  </section>
+  <section class="unit-card">
+    <header><h3>Disco J:</h3></header>
+    <p>Unidad de soporte: guarda copias en cuarentena y los listados finales para consultas rápidas.</p>
+    <ul class="legend-list">
+      <li class="legend-item">
+        <strong>_quarantine_from_I</strong>
+        <div class="legend-meta">23.732 archivos · 273,32&nbsp;GB (81,9&nbsp;% de J:)</div>
+        <div class="legend-note">Duplicados procedentes de I:, preservados antes de decidir el borrado definitivo.</div>
+      </li>
+      <li class="legend-item">
+        <strong>VIDEO</strong>
+        <div class="legend-meta">76 archivos · 55,95&nbsp;GB (16,8&nbsp;%)</div>
+        <div class="legend-note">Copias aprobadas que se mantienen accesibles en esta unidad de apoyo.</div>
+      </li>
+      <li class="legend-item">
+        <strong>_quarantine_from_H</strong>
+        <div class="legend-meta">1.754 archivos · 4,43&nbsp;GB (1,3&nbsp;%)</div>
+        <div class="legend-note">Respaldo de lo retirado en H: por si hiciera falta deshacer algún movimiento.</div>
+      </li>
+    </ul>
+  </section>
+</div>
+
+<h2>Cuarentena en detalle</h2>
+<table>
+  <thead>
+    <tr><th>Ubicación</th><th class="num">Archivos</th><th class="num">GB</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>H:\\_quarantine_from_HIJ\\media_final</td><td class="num">177</td><td class="num">277,31</td></tr>
+    <tr><td>J:\\_quarantine_from_I\\migrated</td><td class="num">20.002</td><td class="num">255,46</td></tr>
+    <tr><td>H:\\_quarantine_from_HIJ\\VIDEOS FAMILIA</td><td class="num">263</td><td class="num">246,67</td></tr>
+    <tr><td>H:\\offload\\_quarantine_from_I</td><td class="num">1.091</td><td class="num">91,06</td></tr>
+    <tr><td>I:\\_quarantine\\migrated</td><td class="num">4.397</td><td class="num">89,38</td></tr>
+    <tr><td>H:\\_quarantine_from_HIJ\\_quarantine_from_H</td><td class="num">14.544</td><td class="num">34,86</td></tr>
+    <tr><td>H:\\_quarantine_from_HIJ\\_quarantine_from_I</td><td class="num">3.871</td><td class="num">34,62</td></tr>
+    <tr><td>H:\\_quarantine_from_HIJ\\offload</td><td class="num">2.951</td><td class="num">16,02</td></tr>
+  </tbody>
+</table>
+<p class="tiny">Total cuarentena: 59.420 archivos y 1,12&nbsp;TB. Siempre es posible recuperar cualquier elemento porque las rutas originales quedan registradas en el índice por hash.</p>
+
+<h2>Cronología del saneamiento de septiembre de 2025</h2>
+<div class="timeline">
+  <div class="t-item">
+    <div class="t-date">04/09 · Limpieza técnica</div>
+    <div class="t-body">Se detectan 3.106 ficheros de sistema (<code>.Spotlight-V100</code>, <code>FOUND.000</code>) y se apartan a cuarentena para evitar confusiones.</div>
+  </div>
+  <div class="t-item">
+    <div class="t-date">10/09 · Documentales HD agrupados</div>
+    <div class="t-body">15 vídeos <code>.m2ts</code> como <em>ALERTA ASTEROIDES</em> o <em>LA CIUDAD PERFECTA</em> se centralizan en la cuarentena común para revisar calidad antes de borrar duplicados.</div>
+  </div>
+  <div class="t-item">
+    <div class="t-date">11/09 · Astronomía y álbumes familiares</div>
+    <div class="t-body">Colecciones especializadas (astronomía, “CASA 2009”) se mueven a <code>H:\\_quarantine_from_HIJ</code> para dejar las unidades principales limpias.</div>
+  </div>
+  <div class="t-item">
+    <div class="t-date">14/09 · Métricas de trabajo</div>
+    <div class="t-body">Se generan <code>session_kpis.csv</code> y <code>timings_by_drive.csv</code>, que recogen tiempos, aciertos y reintentos por unidad.</div>
+  </div>
+  <div class="t-item">
+    <div class="t-date">19/09 · Reintentos controlados</div>
+    <div class="t-body">El fichero <code>moves_retry_log.csv</code> documenta los archivos con incidencias y cómo se solucionaron.</div>
+  </div>
+  <div class="t-item">
+    <div class="t-date">21/09 · Movimientos definitivos</div>
+    <div class="t-body"><code>moves_log.csv</code> cierra la consolidación registrando cada traslado correcto entre discos.</div>
+  </div>
+  <div class="t-item">
+    <div class="t-date">22-23/09 · Validación final</div>
+    <div class="t-body">Se emiten los listados <code>contenido-J-drive.csv</code>/<code>.xlsx</code> y el <em>Índice por hash</em> con 60.639 entradas. La familia puede revisar todo desde los anexos interactivos.</div>
+  </div>
+</div>
+
+<h2>Recomendaciones y siguientes pasos</h2>
+<ul>
+  <li><strong>Revisión familiar.</strong> Dedicar una sesión conjunta a revisar <code>H:\\Media_Final</code> y decidir qué material pasa al álbum compartido definitivo.</li>
+  <li><strong>Decidir el futuro de la cuarentena.</strong> Una vez validadas las carpetas, copiar <code>H:\\_quarantine_from_HIJ</code> a un disco externo y liberar espacio local si se desea.</li>
+  <li><strong>Priorizar los vídeos <code>.m2ts</code> y <code>.mpg</code>.</strong> Son responsables del 89,9&nbsp;% del espacio duplicado. Convertirlos o consolidarlos libera cientos de gigas.</li>
+  <li><strong>Respaldar el disco I:</strong> es el más voluminoso (1,81&nbsp;TB) pero con pocos archivos críticos; una copia de seguridad periódica garantiza la conservación.</li>
+  <li><strong>Documentar nuevas importaciones.</strong> Guardar siempre los listados actualizados (por ejemplo, repetir la exportación de <code>index_by_hash.csv</code>) tras cada sesión para mantener la trazabilidad.</li>
+</ul>
+
+<h2>Metodología y anexos</h2>
+<p>Las cifras proceden de los ficheros generados por el propio proyecto HIJ:</p>
+<ul>
+  <li><code>index_by_hash.csv</code>: inventario completo con 60.639 entradas, hashes y fechas.</li>
+  <li><code>dupes_confirmed.csv</code> y agrupaciones por hash: confirman los duplicados y permiten calcular el espacio liberable.</li>
+  <li><code>moves_log.csv</code> y <code>moves_retry_log.csv</code>: registran qué se movió, cuándo y con qué incidencias.</li>
+  <li>Listados interactivos <code>Listado_H_interactivo.html</code>, <code>Listado_I_interactivo.html</code> y <code>Listado_J_interactivo.html</code>: exploración carpeta por carpeta.</li>
+</ul>
+
+<div class="callout"><strong>¿Necesitas comprobar algo en detalle?</strong> Abre los anexos de abajo y navega por los árboles completos sin salir del informe.</div>
+
+<section class="annexes">
+  <details>
+    <summary>Listado interactivo del disco H:</summary>
+    <div class="iframe-wrapper">
+      <iframe src="Listado_H_interactivo.html" title="Árbol interactivo del disco H"></iframe>
+    </div>
+    <p class="iframe-note">Si el visor no se muestra, abre el archivo <code>Listado_H_interactivo.html</code> directamente en el navegador.</p>
+  </details>
+  <details>
+    <summary>Listado interactivo del disco I:</summary>
+    <div class="iframe-wrapper">
+      <iframe src="Listado_I_interactivo.html" title="Árbol interactivo del disco I"></iframe>
+    </div>
+    <p class="iframe-note">Incluye buscador para localizar rápidamente cualquier documental o carpeta familiar.</p>
+  </details>
+  <details>
+    <summary>Listado interactivo del disco J:</summary>
+    <div class="iframe-wrapper">
+      <iframe src="Listado_J_interactivo.html" title="Árbol interactivo del disco J"></iframe>
+    </div>
+    <p class="iframe-note">Perfecto para seguir el rastro de los volcados desde I: y H:, o para descargar un listado en PDF.</p>
+  </details>
+</section>
+
+<footer>
+  Informe elaborado con los datos consolidados el 23/09/2025. Cualquier cambio posterior debe reflejarse repitiendo la exportación del índice y actualizando este documento.</footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- rebuild `informe_cronologico.html` with a chronological narrative, summary cards, and family-friendly guidance covering 1995-2025
- add data-driven charts and per-drive breakdowns drawn from `index_by_hash.csv` to quantify duplicates, storage distribution, and quarantine hot spots
- document the September 2025 clean-up milestones, follow-up recommendations, and embed the interactive listings for H:, I:, and J:

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d29eeabad4832a8197a7968fb838e0