### PR TITLE
feat: permitir descargar CSV del listado de duplicados

### DIFF
--- a/docs/Listado_Duplicados_interactivo.html
+++ b/docs/Listado_Duplicados_interactivo.html
@@ -258,6 +258,7 @@ footer {
     <span class="filter-chip" data-type="otro">Otros</span>
   </div>
   <label class="toggle"><input type="checkbox" id="multi" /> Solo multi-unidad</label>
+  <button id="download" class="filter-chip">Descargar CSV</button>
   <button id="reset" class="filter-chip">Limpiar filtros</button>
 </div>
 <div class="legend">
@@ -313,6 +314,7 @@ footer {
   let multiOnly = false;
   const columnFilters = { sha:'', role:'', type:'', name:'', path:'', drive:'', size:'', last:'' };
   const sortConfig = { field: null, direction: 'asc' };
+  let lastFilteredGroups = [];
 
   const searchInput = document.getElementById('search');
   const chips = document.querySelectorAll('.filter-chip[data-drive], .filter-chip[data-type]');
@@ -323,6 +325,7 @@ footer {
   const statSize = document.getElementById('stat-size');
   const headers = document.querySelectorAll('th[data-sort]');
   const columnInputs = document.querySelectorAll('tr.column-filters input[data-filter]');
+  const downloadBtn = document.getElementById('download');
 
   document.getElementById('stat-groups').textContent = groups.length.toLocaleString('es-ES');
 
@@ -354,6 +357,12 @@ footer {
 
   function normalise(value) {
     return (value || '').toString().toLowerCase();
+  }
+
+  function csvCell(value) {
+    const string = value == null ? '' : value.toString();
+    const escaped = string.replace(/"/g, '""');
+    return `"${escaped}"`;
   }
 
   function getEntryField(entry, field) {
@@ -428,7 +437,16 @@ footer {
 
     filteredGroups.sort(compareGroups);
 
-    filteredGroups.forEach((groupWrapper) => {
+    const snapshot = filteredGroups.map((groupWrapper) => {
+      const sortedEntries = [...groupWrapper.entries];
+      if(sortConfig.field && sortConfig.field !== 'sha') {
+        const factor = sortConfig.direction === 'desc' ? -1 : 1;
+        sortedEntries.sort((a, b) => compareEntries(a, b, sortConfig.field) * factor);
+      }
+      return { groupInfo: groupWrapper.groupInfo, entries: sortedEntries };
+    });
+
+    snapshot.forEach((groupWrapper) => {
       const info = groupWrapper.groupInfo;
       rendered.push(`
         <tr class="group-row" data-group="${info.group}" data-open="true">
@@ -439,15 +457,9 @@ footer {
             <span class="badge">SHA: ${escapeHtml(info.sha)}</span>
           </td>
         </tr>`);
-      const sortedEntries = [...groupWrapper.entries];
-      if(sortConfig.field && sortConfig.field !== 'sha') {
-        const factor = sortConfig.direction === 'desc' ? -1 : 1;
-        sortedEntries.sort((a, b) => compareEntries(a, b, sortConfig.field) * factor);
-      }
-      sortedEntries.forEach((entry) => {
+      groupWrapper.entries.forEach((entry) => {
         visibleEntries += 1;
         visibleBytes += entry.bytes || 0;
-        const disabled = entry.openUri ? '' : ' aria-disabled="true"';
         rendered.push(`
           <tr class="entry-row" data-group="${info.group}">
             <td>${info.group}</td>
@@ -470,6 +482,7 @@ footer {
     tbody.innerHTML = rendered.join('');
     statVisible.textContent = visibleEntries.toLocaleString('es-ES');
     statSize.textContent = formatBytes(visibleBytes);
+    lastFilteredGroups = snapshot;
   }
 
   tbody.addEventListener('click', (event) => {
@@ -542,6 +555,62 @@ footer {
     columnInputs.forEach((input) => input.value = '');
     render();
   });
+
+  if(downloadBtn) {
+    downloadBtn.addEventListener('click', () => {
+      if(downloadBtn.disabled) return;
+      const originalText = downloadBtn.textContent;
+      const hasRows = lastFilteredGroups.some((group) => group.entries.length > 0);
+      if(!hasRows) {
+        downloadBtn.textContent = 'Sin resultados visibles';
+        setTimeout(() => downloadBtn.textContent = originalText, 2000);
+        return;
+      }
+
+      downloadBtn.disabled = true;
+      downloadBtn.textContent = 'Generando CSV...';
+
+      try {
+        const headers = ['Grupo', 'SHA256', 'Rol', 'Tipo', 'Nombre', 'Ubicación', 'Unidad', 'Tamaño', 'Modificado'];
+        const rows = [];
+        lastFilteredGroups.forEach((groupWrapper) => {
+          groupWrapper.entries.forEach((entry) => {
+            rows.push([
+              groupWrapper.groupInfo.group,
+              entry.sha,
+              entry.role,
+              entry.category,
+              entry.name,
+              entry.path,
+              entry.drive,
+              entry.sizeLabel,
+              entry.lastWrite || ''
+            ]);
+          });
+        });
+        const lines = [headers, ...rows].map((row) => row.map(csvCell).join(';'));
+        const csvContent = lines.join('\r\n');
+        const blob = new Blob([`\uFEFF${csvContent}`], { type: 'text/csv;charset=utf-8;' });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        const timestamp = new Date().toISOString().replace(/[:T]/g, '-').split('.')[0];
+        link.download = `duplicados-filtrados-${timestamp}.csv`;
+        document.body.appendChild(link);
+        link.click();
+        link.remove();
+        URL.revokeObjectURL(url);
+        downloadBtn.textContent = 'CSV descargado ✓';
+        setTimeout(() => downloadBtn.textContent = originalText, 2000);
+      } catch (error) {
+        console.error(error);
+        downloadBtn.textContent = 'Error al generar';
+        setTimeout(() => downloadBtn.textContent = originalText, 2000);
+      } finally {
+        downloadBtn.disabled = false;
+      }
+    });
+  }
 
   headers.forEach((header) => {
     header.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- add a CSV download control to the toolbar of the duplicates explorer
- generate the CSV from the currently rendered groups and manage the button state during export

## Testing
- not run (static change)


------
https://chatgpt.com/codex/tasks/task_e_68dd56e2e600832a97bca278614062e4