### PR TITLE
feat: add folder summary panel to inventory outputs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -41,6 +41,11 @@
   tbody tr:hover{outline:1px solid var(--accent)}
   td.path{font-family:Consolas,Monaco,monospace}
   .small{font-size:12px}
+  .nowrap{white-space:nowrap}
+  .summary-table{width:100%;border-collapse:collapse;margin-top:10px;font-size:13px}
+  .summary-table thead th{background:#0b1220;color:#e2e8f0;text-align:left;padding:8px;border-bottom:1px solid #1f2937}
+  .summary-table tbody td{padding:6px 8px;border-bottom:1px solid #1f2937;color:#cbd5e1}
+  .summary-table tbody tr:hover{background:#17233b}
 </style>
 </head><body><div class="wrap">
 <h1>Inventario H/I/J (offline)</h1>
@@ -96,6 +101,21 @@
 <li><span class='tag'>.DB</span> 186 archivos &middot; 0,03 GB</li>
 <li><span class='tag'>.CSV</span> 5 archivos &middot; 0,01 GB</li>
 </ul>
+</section>
+<section class='panel'>
+<h2>Resumen por carpeta principal</h2>
+<p>Ranking de carpetas superiores ordenadas por espacio ocupado (hasta 12 entradas).</p>
+<table class='summary-table'>
+<thead><tr><th>Unidad</th><th>Carpeta</th><th>Archivos</th><th>GB</th></tr></thead><tbody>
+<tr><td>I</td><td>I:\PELICULAS</td><td class='nowrap'>242</td><td class='nowrap'>954,05 GB</td></tr>
+<tr><td>I</td><td>I:\VIDEOS CIENCIA Y TECNOLOGIA</td><td class='nowrap'>387</td><td class='nowrap'>668,91 GB</td></tr>
+<tr><td>H</td><td>H:\Media_Final</td><td class='nowrap'>193</td><td class='nowrap'>350,41 GB</td></tr>
+<tr><td>I</td><td>I:\FAMILIA</td><td class='nowrap'>48</td><td class='nowrap'>97,41 GB</td></tr>
+<tr><td>J</td><td>J:\VIDEO</td><td class='nowrap'>76</td><td class='nowrap'>55,95 GB</td></tr>
+<tr><td>I</td><td>I:\</td><td class='nowrap'>1</td><td class='nowrap'>31,88 GB</td></tr>
+<tr><td>I</td><td>I:\media_final</td><td class='nowrap'>1</td><td class='nowrap'>1,40 GB</td></tr>
+<tr><td>H</td><td>H:\VIDEOS FAMILIA</td><td class='nowrap'>4</td><td class='nowrap'>0,20 GB</td></tr>
+</tbody></table>
 </section>
 <section class='panel dataset'>
 <h2>Explorador interactivo</h2>

--- a/inventario_interactivo_offline.html
+++ b/inventario_interactivo_offline.html
@@ -41,6 +41,11 @@
   tbody tr:hover{outline:1px solid var(--accent)}
   td.path{font-family:Consolas,Monaco,monospace}
   .small{font-size:12px}
+  .nowrap{white-space:nowrap}
+  .summary-table{width:100%;border-collapse:collapse;margin-top:10px;font-size:13px}
+  .summary-table thead th{background:#0b1220;color:#e2e8f0;text-align:left;padding:8px;border-bottom:1px solid #1f2937}
+  .summary-table tbody td{padding:6px 8px;border-bottom:1px solid #1f2937;color:#cbd5e1}
+  .summary-table tbody tr:hover{background:#17233b}
 </style>
 </head><body><div class="wrap">
 <h1>Inventario H/I/J (offline)</h1>
@@ -96,6 +101,21 @@
 <li><span class='tag'>.DB</span> 186 archivos &middot; 0,03 GB</li>
 <li><span class='tag'>.CSV</span> 5 archivos &middot; 0,01 GB</li>
 </ul>
+</section>
+<section class='panel'>
+<h2>Resumen por carpeta principal</h2>
+<p>Ranking de carpetas superiores ordenadas por espacio ocupado (hasta 12 entradas).</p>
+<table class='summary-table'>
+<thead><tr><th>Unidad</th><th>Carpeta</th><th>Archivos</th><th>GB</th></tr></thead><tbody>
+<tr><td>I</td><td>I:\PELICULAS</td><td class='nowrap'>242</td><td class='nowrap'>954,05 GB</td></tr>
+<tr><td>I</td><td>I:\VIDEOS CIENCIA Y TECNOLOGIA</td><td class='nowrap'>387</td><td class='nowrap'>668,91 GB</td></tr>
+<tr><td>H</td><td>H:\Media_Final</td><td class='nowrap'>193</td><td class='nowrap'>350,41 GB</td></tr>
+<tr><td>I</td><td>I:\FAMILIA</td><td class='nowrap'>48</td><td class='nowrap'>97,41 GB</td></tr>
+<tr><td>J</td><td>J:\VIDEO</td><td class='nowrap'>76</td><td class='nowrap'>55,95 GB</td></tr>
+<tr><td>I</td><td>I:\</td><td class='nowrap'>1</td><td class='nowrap'>31,88 GB</td></tr>
+<tr><td>I</td><td>I:\media_final</td><td class='nowrap'>1</td><td class='nowrap'>1,40 GB</td></tr>
+<tr><td>H</td><td>H:\VIDEOS FAMILIA</td><td class='nowrap'>4</td><td class='nowrap'>0,20 GB</td></tr>
+</tbody></table>
 </section>
 <section class='panel dataset'>
 <h2>Explorador interactivo</h2>

--- a/make_inventory_offline.ps1
+++ b/make_inventory_offline.ps1
@@ -169,6 +169,11 @@ try {
   tbody tr:hover{outline:1px solid var(--accent)}
   td.path{font-family:Consolas,Monaco,monospace}
   .small{font-size:12px}
+  .nowrap{white-space:nowrap}
+  .summary-table{width:100%;border-collapse:collapse;margin-top:10px;font-size:13px}
+  .summary-table thead th{background:#0b1220;color:#e2e8f0;text-align:left;padding:8px;border-bottom:1px solid #1f2937}
+  .summary-table tbody td{padding:6px 8px;border-bottom:1px solid #1f2937;color:#cbd5e1}
+  .summary-table tbody tr:hover{background:#17233b}
 </style>
 "@
 
@@ -377,6 +382,33 @@ try {
       $null = $sb.AppendLine("<li><span class='tag'>$safeLabel</span> $countFmt archivos &middot; $gbFmt GB</li>")
     }
     $null = $sb.AppendLine('</ul>')
+    $null = $sb.AppendLine('</section>')
+  }
+
+  $folderRanking = @()
+  if ($topFolders) {
+    $folderRanking = @($topFolders | Where-Object { $_.GB -gt 0.05 } | Sort-Object GB -Descending)
+    if (-not $folderRanking.Count) {
+      $folderRanking = @($topFolders | Sort-Object GB -Descending | Select-Object -First 12)
+    } else {
+      $folderRanking = @($folderRanking | Select-Object -First 12)
+    }
+  }
+
+  if ($folderRanking.Count) {
+    $null = $sb.AppendLine("<section class='panel'>")
+    $null = $sb.AppendLine("<h2>Resumen por carpeta principal</h2>")
+    $null = $sb.AppendLine("<p>Ranking de carpetas superiores ordenadas por espacio ocupado (hasta 12 entradas).</p>")
+    $null = $sb.AppendLine("<table class='summary-table'>")
+    $null = $sb.AppendLine("<thead><tr><th>Unidad</th><th>Carpeta</th><th>Archivos</th><th>GB</th></tr></thead><tbody>")
+    foreach ($entry in $folderRanking) {
+      $folderLabel = if ($entry.Folder -eq '(raiz)') { '{0}:\\ (raíz)' -f $entry.Drive } else { '{0}:\\{1}' -f $entry.Drive, $entry.Folder }
+      $safeLabel = HtmlEnc($folderLabel)
+      $countFmt = [string]::Format('{0:n0}', $entry.Count)
+      $gbFmt = [string]::Format('{0:n2}', $entry.GB)
+      $null = $sb.AppendLine("<tr><td>$($entry.Drive)</td><td>$safeLabel</td><td class='nowrap'>$countFmt</td><td class='nowrap'>$gbFmt GB</td></tr>")
+    }
+    $null = $sb.AppendLine('</tbody></table>')
     $null = $sb.AppendLine('</section>')
   }
 

--- a/update_pages_inventory.ps1
+++ b/update_pages_inventory.ps1
@@ -170,6 +170,11 @@ $css = @"
   tbody tr:hover{outline:1px solid var(--accent)}
   td.path{font-family:Consolas,Monaco,monospace}
   .small{font-size:12px}
+  .nowrap{white-space:nowrap}
+  .summary-table{width:100%;border-collapse:collapse;margin-top:10px;font-size:13px}
+  .summary-table thead th{background:#0b1220;color:#e2e8f0;text-align:left;padding:8px;border-bottom:1px solid #1f2937}
+  .summary-table tbody td{padding:6px 8px;border-bottom:1px solid #1f2937;color:#cbd5e1}
+  .summary-table tbody tr:hover{background:#17233b}
 </style>
 "@
 $js = @"
@@ -391,6 +396,33 @@ if ($topExtensions) {
     $null = $sb.AppendLine("<li><span class='tag'>$safeLabel</span> $countFmt archivos &middot; $gbFmt GB</li>")
   }
   $null = $sb.AppendLine('</ul>')
+  $null = $sb.AppendLine('</section>')
+}
+
+$folderRanking = @()
+if ($topFolders) {
+  $folderRanking = @($topFolders | Where-Object { $_.GB -gt 0.05 } | Sort-Object GB -Descending)
+  if (-not $folderRanking.Count) {
+    $folderRanking = @($topFolders | Sort-Object GB -Descending | Select-Object -First 12)
+  } else {
+    $folderRanking = @($folderRanking | Select-Object -First 12)
+  }
+}
+
+if ($folderRanking.Count) {
+  $null = $sb.AppendLine("<section class='panel'>")
+  $null = $sb.AppendLine("<h2>Resumen por carpeta principal</h2>")
+  $null = $sb.AppendLine("<p>Ranking de carpetas superiores ordenadas por espacio ocupado (hasta 12 entradas).</p>")
+  $null = $sb.AppendLine("<table class='summary-table'>")
+  $null = $sb.AppendLine("<thead><tr><th>Unidad</th><th>Carpeta</th><th>Archivos</th><th>GB</th></tr></thead><tbody>")
+  foreach ($entry in $folderRanking) {
+    $folderLabel = if ($entry.Folder -eq '(raiz)') { '{0}:\\ (raíz)' -f $entry.Drive } else { '{0}:\\{1}' -f $entry.Drive, $entry.Folder }
+    $safeLabel = HtmlEnc($folderLabel)
+    $countFmt = [string]::Format('{0:n0}', $entry.Count)
+    $gbFmt = [string]::Format('{0:n2}', $entry.GB)
+    $null = $sb.AppendLine("<tr><td>$($entry.Drive)</td><td>$safeLabel</td><td class='nowrap'>$countFmt</td><td class='nowrap'>$gbFmt GB</td></tr>")
+  }
+  $null = $sb.AppendLine('</tbody></table>')
   $null = $sb.AppendLine('</section>')
 }
 $null = $sb.AppendLine("<section class='panel dataset'>")


### PR DESCRIPTION
## Summary
- add reusable styles for compact summary tables in inventory templates
- compute a ranking of top-level folders by occupied size in offline and Pages scripts
- surface the folder ranking in the generated HTML inventories for quick review

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de7995379c832a881fe02f076e22fd