### PR TITLE
fix: normalize file links for Windows paths

### DIFF
--- a/make_inventory_offline.ps1
+++ b/make_inventory_offline.ps1
@@ -229,7 +229,7 @@ try {
 
   function buildRow(row){
     const rawPath = row.FullPath || '';
-    const href = 'file:///' + rawPath.split('\\').join('/');
+    const href = 'file:///' + rawPath.split('\').join('/');
     const size = Number(row.MB ?? 0);
     const sizeCell = Number.isFinite(size) ? size.toFixed(2) : '0.00';
     const safeDrive = escapeHtml(row.Drive || '');

--- a/update_pages_inventory.ps1
+++ b/update_pages_inventory.ps1
@@ -229,7 +229,7 @@ $js = @"
 
   function buildRow(row){
     const rawPath = row.FullPath || '';
-    const href = 'file:///' + rawPath.split('\\').join('/');
+    const href = 'file:///' + rawPath.split('\').join('/');
     const size = Number(row.MB ?? 0);
     const sizeCell = Number.isFinite(size) ? size.toFixed(2) : '0.00';
     const safeDrive = escapeHtml(row.Drive || '');


### PR DESCRIPTION
## Summary
- replace the double-backslash splitter with a single backslash so generated file:// links open correctly in both inventories

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de9bd6fc84832ab64ddd4948939db0