### PR TITLE
Add MCP metadata for resources and tools

### DIFF
--- a/docs/mcp/resources.json
+++ b/docs/mcp/resources.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://modelcontextprotocol.dev/schemas/resources.schema.json",
+  "version": "1.0",
+  "resources": [
+    {
+      "name": "dupes_confirmed.csv",
+      "path": "dupes_confirmed.csv",
+      "description": "Listado consolidado de duplicados confirmados",
+      "columns": [
+        { "name": "hash", "type": "string", "description": "SHA256 del archivo" },
+        { "name": "path", "type": "string", "description": "Ruta completa" },
+        { "name": "size", "type": "integer", "description": "Bytes" },
+        { "name": "modified", "type": "datetime", "description": "Última modificación" }
+      ]
+    },
+    {
+      "name": "inventory_by_folder.csv",
+      "path": "inventory_by_folder.csv",
+      "description": "Agregado por carpeta (conteos, tamaños)",
+      "columns": [
+        { "name": "folder", "type": "string" },
+        { "name": "files", "type": "integer" },
+        { "name": "bytes", "type": "integer" }
+      ]
+    },
+    {
+      "name": "inventario_offline",
+      "path": "docs/inventario_interactivo_offline.html",
+      "description": "Inventario HTML interactivo (filtros, búsqueda, descarga) generado por make_inventory_offline.ps1",
+      "format": "text/html"
+    }
+  ]
+}

--- a/docs/mcp/tools.json
+++ b/docs/mcp/tools.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://modelcontextprotocol.dev/schemas/tools.schema.json",
+  "version": "1.0",
+  "tools": [
+    {
+      "name": "Move-I-Duplicates",
+      "language": "powershell",
+      "path": "tools/Move-I-Duplicates.ps1",
+      "description": "Mueve archivos duplicados desde una ubicación origen a una carpeta destino.",
+      "inputs": {
+        "SourceDir": { "type": "string", "required": true, "description": "Ruta de origen" },
+        "TargetDir": { "type": "string", "required": true, "description": "Ruta de destino" },
+        "WhatIf":    { "type": "boolean", "required": false, "default": true, "description": "Simulación sin mover" }
+      },
+      "outputs": {
+        "LogFile": { "type": "string", "description": "Ruta del log generado" }
+      },
+      "permissions": ["read", "write"]
+    },
+    {
+      "name": "remove_nonmedia_duplicates",
+      "language": "python",
+      "path": "tools/remove_nonmedia_duplicates.py",
+      "description": "Filtra/elimina duplicados no multimedia en un CSV de inventario.",
+      "inputs": {
+        "InventoryFile": { "type": "string", "required": true, "description": "Ruta al CSV de inventario" },
+        "OutFile":       { "type": "string", "required": false, "description": "CSV de salida limpio" }
+      },
+      "outputs": {
+        "CleanedFile": { "type": "string", "description": "Ruta del CSV resultante" }
+      },
+      "permissions": ["read", "write"]
+    },
+    {
+      "name": "make_inventory_offline",
+      "language": "powershell",
+      "path": "tools/make_inventory_offline.ps1",
+      "description": "Genera un inventario HTML offline (tablas filtrables, descarga, etc.).",
+      "inputs": {
+        "ScanDir":   { "type": "string", "required": true, "description": "Carpeta o disco a inventariar" },
+        "OutputDir": { "type": "string", "required": false, "description": "Carpeta de salida (por defecto docs/)" }
+      },
+      "outputs": {
+        "InventoryHtml": { "type": "string", "description": "Ruta del HTML generado" }
+      },
+      "permissions": ["read", "write"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add Model Context Protocol resource metadata for key inventory artifacts
- register existing PowerShell and Python utilities as MCP tools with schemas

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfe3b0808c832a9f54e33aef37dcc1