### PR TITLE
fix: normalize offline inventory file links

### DIFF
--- a/make_inventory_offline.ps1
+++ b/make_inventory_offline.ps1
@@ -362,17 +362,17 @@ try {
       pathValue = pathValue.slice(4);
     }
     pathValue = pathValue.replace(/\//g, '\');
-    const driveMatch = pathValue.match(/^([A-Za-z]):\(.*)$/);
+    const driveMatch = pathValue.match(/^([A-Za-z]):\\(.*)$/);
     if (!driveMatch) { return ''; }
     const drive = driveMatch[1];
-    const remainder = driveMatch[2];
-    const segments = remainder.split(/\+/).filter(Boolean).map(encodeURIComponent);
+    const remainder = driveMatch[2] || '';
+    const segments = remainder
+      .split(/\\+/)
+      .filter(Boolean)
+      .map(segment => encodeURIComponent(segment));
     const tail = segments.join('/');
     return tail ? ('file:///' + drive + ':/' + tail) : ('file:///' + drive + ':/');
   }
-
-
-
   function buildRow(row){
     const rawPath = row.FullPath || '';
     const size = Number(row.MB ?? 0);


### PR DESCRIPTION
## Summary
- update the offline inventory HTML template to detect drive-qualified paths with an explicit backslash
- split Windows path remainders on backslashes, filter empty segments, and encode each component before building file:/// URIs

## Testing
- pwsh -NoProfile -ExecutionPolicy Bypass -File make_inventory_offline.ps1 *(fails: `pwsh` is not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e09610ab04832a81d3158e63351cca