### PR TITLE
chore(agent): orchestrate full inventory pipeline

### DIFF
--- a/docs/mcp/agents.json
+++ b/docs/mcp/agents.json
@@ -12,12 +12,22 @@
         "SweepMode": "None"
       },
       "tools_used": [
-        "tools/Move-I-Duplicates.ps1",
+        "tools/agents/repo-sweep.ps1",
         "tools/remove_nonmedia_duplicates.py",
-        "tools/make_inventory_offline.ps1"
+        "tools/Move-I-Duplicates.ps1",
+        "tools/build-hash-data.ps1",
+        "make_inventory_offline.ps1",
+        "tools/agents/make-inventory-offline-wrapper.ps1",
+        "tools/normalize-inventory-html.ps1",
+        "tools/inventory-inject-from-csv.ps1",
+        "tools/sanitize-inventory-html.ps1",
+        "tools/generate_duplicates_table.py"
       ],
       "artifacts": [
         "docs/inventario_interactivo_offline.html",
+        "docs/hash_data.csv",
+        "docs/Listado_Duplicados_interactivo.html",
+        "logs/make-inventory-wrapper.log",
         "logs/inventory-cleaner-*.log",
         "logs/repo-sweep-*.log",
         "logs/repo-sweep-dryrun-*.csv",

--- a/docs/mcp/tools.json
+++ b/docs/mcp/tools.json
@@ -44,6 +44,35 @@
         "InventoryHtml": { "type": "string", "description": "Ruta del HTML generado" }
       },
       "permissions": ["read", "write"]
+    },
+    {
+      "name": "build_hash_data",
+      "language": "powershell",
+      "path": "tools/build-hash-data.ps1",
+      "description": "Reconstruye docs/hash_data.csv a partir de index_by_hash.csv sin reescanear las unidades.",
+      "inputs": {
+        "RepoRoot": { "type": "string", "required": false, "description": "Raíz del repositorio" },
+        "IndexPath": { "type": "string", "required": false, "description": "CSV base index_by_hash.csv" },
+        "OutputCsv": { "type": "string", "required": false, "description": "Destino para hash_data.csv" }
+      },
+      "outputs": {
+        "HashCsv": { "type": "string", "description": "Ruta del CSV normalizado" }
+      },
+      "permissions": ["read", "write"]
+    },
+    {
+      "name": "generate_duplicates_table",
+      "language": "python",
+      "path": "tools/generate_duplicates_table.py",
+      "description": "Construye el visor interactivo de duplicados a partir de dupes_confirmed.csv.",
+      "inputs": {
+        "source": { "type": "string", "required": false, "description": "CSV de duplicados (por defecto dupes_confirmed.csv)" },
+        "target": { "type": "string", "required": false, "description": "HTML de salida" }
+      },
+      "outputs": {
+        "DuplicatesHtml": { "type": "string", "description": "Ruta del HTML generado" }
+      },
+      "permissions": ["read", "write"]
     }
   ]
 }

--- a/tools/agents/inventory-cleaner.ps1
+++ b/tools/agents/inventory-cleaner.ps1
@@ -41,6 +41,7 @@ if ($SweepMode -ne "None") {
 
 $PyRemove = Join-Path $RepoRoot "tools/remove_nonmedia_duplicates.py"
 $MoveDupes = Join-Path $RepoRoot "tools/Move-I-Duplicates.ps1"
+$BuildHash = Join-Path $RepoRoot "tools/build-hash-data.ps1"
 $MakeInv = Join-Path $RepoRoot "tools/make_inventory_offline.ps1"
 if (-not (Test-Path $MakeInv)) {
   $MakeInv = Join-Path $RepoRoot "make_inventory_offline.ps1"
@@ -48,6 +49,7 @@ if (-not (Test-Path $MakeInv)) {
 $Wrapper = Join-Path $RepoRoot "tools/agents/make-inventory-offline-wrapper.ps1"
 $Normalizer = Join-Path $RepoRoot "tools/normalize-inventory-html.ps1"
 $Sanitizer = Join-Path $RepoRoot "tools/sanitize-inventory-html.ps1"
+$DupesExplorer = Join-Path $RepoRoot "tools/generate_duplicates_table.py"
 
 $pythonExe = $null
 foreach ($cand in @("python","py","python3")) {
@@ -76,6 +78,19 @@ if ((Test-Path $MoveDupes) -and (Test-Path $DupesCsvPath)) {
   & $MoveDupes -CsvPath "$DupesCsvPath" 2>&1 | Tee-Object -FilePath $LogFile -Append
 } else {
   Log "SKIP: falta Move-I-Duplicates.ps1 o $DupesCsvPath"
+}
+
+$hashDataPath = Join-Path $OutputDirPath "hash_data.csv"
+if (Test-Path $BuildHash) {
+  Log "Regenerando docs/hash_data.csv ..."
+  & $BuildHash -RepoRoot "$RepoRoot" -IndexPath "index_by_hash.csv" -OutputCsv "$hashDataPath" 2>&1 | Tee-Object -FilePath $LogFile -Append
+  if (Test-Path $hashDataPath) {
+    Log "OK: hash_data.csv actualizado"
+  } else {
+    Log "WARN: build-hash-data.ps1 no produjo $hashDataPath"
+  }
+} else {
+  Log "SKIP: tools/build-hash-data.ps1 no encontrado"
 }
 
 $ExpectedHtml = Join-Path $OutputDirPath "inventario_interactivo_offline.html"
@@ -121,6 +136,25 @@ if (Test-Path $ExpectedHtml) {
   Log "OK: HTML generado -> $ExpectedHtml"
 } else {
   Log "WARN: No se encontro $ExpectedHtml tras la ejecucion."
+}
+
+$dupesHtml = Join-Path $OutputDirPath "Listado_Duplicados_interactivo.html"
+if (Test-Path $DupesExplorer) {
+  if (-not (Test-Path $DupesCsvPath)) {
+    Log "SKIP: dupes_confirmed.csv no encontrado; no se genera Listado_Duplicados_interactivo.html"
+  } elseif ($pythonExe) {
+    Log "Generando Listado_Duplicados_interactivo.html ..."
+    & $pythonExe "$DupesExplorer" --source "$DupesCsvPath" --target "$dupesHtml" 2>&1 | Tee-Object -FilePath $LogFile -Append
+    if (Test-Path $dupesHtml) {
+      Log "OK: Listado_Duplicados_interactivo.html actualizado"
+    } else {
+      Log "WARN: No se encontro $dupesHtml tras ejecutar generate_duplicates_table.py"
+    }
+  } else {
+    Log "WARN: Python no detectado; se omite generate_duplicates_table.py"
+  }
+} else {
+  Log "SKIP: tools/generate_duplicates_table.py no encontrado"
 }
 
 Log "== Inventory-Cleaner DONE =="

--- a/tools/agents/make-inventory-offline-wrapper.ps1
+++ b/tools/agents/make-inventory-offline-wrapper.ps1
@@ -109,18 +109,27 @@ try {
       [string]$ExistingSummary
     )
     if ($ExistingSummary) { return $ExistingSummary }
-    $parts = New-Object System.Collections.Generic.List[string]
-    $parts.Add("Total: {0}" -f $Rows.Count) | Out-Null
+    $segments = New-Object System.Collections.Generic.List[string]
+    $segments.Add("Total: {0}" -f $Rows.Count) | Out-Null
+
+    $hiParts = New-Object System.Collections.Generic.List[string]
     foreach ($letter in @('H','I','J')) {
-      if ($DriveCounts.Contains($letter)) {
-        $parts.Add("{0}: {1} files" -f $letter, $DriveCounts[$letter]) | Out-Null
+      $count = if ($DriveCounts.Contains($letter)) { $DriveCounts[$letter] } else { 0 }
+      $hiParts.Add("{0}: {1}" -f $letter, $count) | Out-Null
+    }
+    if ($hiParts.Count -gt 0) {
+      $segments.Add(($hiParts -join ' · ')) | Out-Null
+    }
+
+    $others = $DriveCounts.Keys | Where-Object { $_ -notin @('H','I','J') } | Sort-Object
+    if ($others) {
+      $extraParts = $others | ForEach-Object { "{0}: {1}" -f $_, $DriveCounts[$_] }
+      if ($extraParts) {
+        $segments.Add(($extraParts -join ' · ')) | Out-Null
       }
     }
-    $others = $DriveCounts.Keys | Where-Object { $_ -notin @('H','I','J') } | Sort-Object
-    foreach ($drive in $others) {
-      $parts.Add("{0}: {1} files" -f $drive, $DriveCounts[$drive]) | Out-Null
-    }
-    return ($parts -join ' | ')
+
+    return ($segments -join ' | ')
   }
 
   function Get-InventorySnapshot {


### PR DESCRIPTION
## Summary
- extend the inventory-cleaner agent to rebuild hash_data.csv and the duplicates explorer before sanitising the inventory HTML
- document the updated orchestration in the MCP agent catalog so the new tools appear in the declared pipeline

## Testing
- not run (PowerShell unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e0870d94c4832ab261e9c59386d9a4