### PR TITLE
docs: refresh README and agent playbook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,19 +1,54 @@
-# Repository Guidelines
+# 🧭 Agent Playbook
 
-## Project Structure & Module Organization
-The root hosts inventory inputs produced by drives (e.g., `index_by_hash.csv`, `inventory_by_folder.csv`) plus orchestrator scripts like `make_inventory_offline.ps1`. Reusable automation lives under `tools/`; `tools/agents/` houses entry-point wrappers (`inventory-cleaner.ps1`), while sibling scripts such as `build-hash-data.ps1`, `inventory-inject-from-csv.ps1`, and `normalize-inventory-html.ps1` implement discrete data steps. Generated artifacts such as `docs/hash_data.csv`, `docs/inventario_interactivo_offline.html`, and duplicate dashboards reside in `docs/`. Treat any file under `docs/` as read-only outputs and regenerate them through the described flows.
+Guía operativa para mantener el flujo autónomo de inventario multimedia.
 
-## Build, Test, and Development Commands
-Run `pwsh -NoProfile -ExecutionPolicy Bypass -File tools/agents/inventory-cleaner.ps1 -RepoRoot . -SweepMode None` to execute the full pipeline: hash refresh, HTML normalization, sanitization, and final offline bundle. Use `pwsh -NoProfile -ExecutionPolicy Bypass -File tools/build-hash-data.ps1 -RepoRoot . -IndexPath index_by_hash.csv` when you only need to refresh `docs/hash_data.csv`. Regenerate duplicate analytics with `python tools/generate_duplicates_table.py --input docs/hash_data.csv --output docs/duplicate_summary.json`.
+---
 
-## Coding Style & Naming Conventions
-PowerShell scripts use 2-space indentation, Verb-Noun command names (`Resolve-InRepo`), and single quotes for literal strings; keep modules ASCII-only. Python utilities follow 4-space indentation, snake_case identifiers, and stay self-contained without external imports. Never edit sanitized HTML or CSV by hand; pipe changes through the provided scripts.
+## 🧱 Arquitectura del repositorio
 
-## Testing Guidelines
-After any pipeline change, rerun the cleaner wrapper and review its log for non-zero row counts and the H/I/J drive summary in the generated HTML. When altering normalization logic, perform `pwsh -File tools/normalize-inventory-html.ps1 -HtmlPath docs/inventario_interactivo_offline.html` as a smoke test. For hash or duplicate adjustments, inspect `docs/hash_data.csv` to confirm the expected columns (`FullName`, `Hash`, `Length`, `Extension`, `Error`) and spot-check representative records.
+| Zona | Contenido | Notas |
+| --- | --- | --- |
+| Raíz | CSV y reportes generados (`index_by_hash.csv`, `inventory_by_folder.csv`) más orquestadores como `make_inventory_offline.ps1`. | Los artefactos se regeneran desde scripts, no se editan manualmente. |
+| `tools/` | Automatizaciones reutilizables. | Los *entry-points* viven en `tools/agents/`; los módulos auxiliares (`build-hash-data.ps1`, `inventory-inject-from-csv.ps1`, `normalize-inventory-html.ps1`) implementan pasos individuales. |
+| `docs/` | Salida pública (`docs/hash_data.csv`, `docs/inventario_interactivo_offline.html`, tableros de duplicados). | Trátalos como read-only; usa los scripts para actualizarlos. |
 
-## Commit & Pull Request Guidelines
-Adopt conventional commit prefixes (`feat`, `fix`, `chore`, `docs`) with optional scopes such as `fix(inventory): guard __DATA__ shim`. PRs should summarize changes, link related Trello cards or issues, and attach before/after evidence when HTML or CSV outputs shift. Commit regenerated artifacts alongside code changes to keep reviewers synchronized.
+---
 
-## Security & Operational Notes
-`docs/hash_data.csv` contains absolute paths and file sizes; share it only with trusted collaborators. Sanitizers intentionally strip external protocols (acestream, http). Extend the blocklist rather than disabling these guards when new protocols appear.
+## 🛠️ Comandos esenciales
+
+| Objetivo | Comando |
+| --- | --- |
+| Pipeline completo (hash → HTML → sanitizado) | `pwsh -NoProfile -ExecutionPolicy Bypass -File tools/agents/inventory-cleaner.ps1 -RepoRoot . -SweepMode None` |
+| Refrescar solo `docs/hash_data.csv` | `pwsh -NoProfile -ExecutionPolicy Bypass -File tools/build-hash-data.ps1 -RepoRoot . -IndexPath index_by_hash.csv` |
+| Regenerar analítica de duplicados | `python tools/generate_duplicates_table.py --input docs/hash_data.csv --output docs/duplicate_summary.json` |
+
+Mantén los scripts idempotentes y sin rutas absolutas codificadas.
+
+---
+
+## 🧩 Estilo y convenciones
+
+- **PowerShell**: Sangría de 2 espacios, comandos `Verbo-Nombre`, usa comillas simples para literales, ASCII puro.
+- **Python**: Sangría de 4 espacios, `snake_case`, sin dependencias externas.
+- **HTML/CSV generados**: nunca los edites a mano; actualízalos mediante los scripts correspondientes.
+
+---
+
+## ✅ Verificaciones recomendadas
+
+1. Después de modificar la tubería, ejecuta el *cleaner* y revisa el log para confirmar los recuentos y el resumen H/I/J en el HTML generado.
+2. Cambios de normalización → `pwsh -File tools/normalize-inventory-html.ps1 -HtmlPath docs/inventario_interactivo_offline.html` como *smoke test*.
+3. Ajustes de hash o duplicados → inspecciona `docs/hash_data.csv` y verifica las columnas `FullName`, `Hash`, `Length`, `Extension`, `Error`.
+
+---
+
+## 📬 Commits y PRs
+
+- Usa prefijos convencionales (`feat`, `fix`, `chore`, `docs`) con un alcance opcional (`fix(inventory): ...`).
+- Los PRs deben resumir cambios, enlazar Trello/issues cuando aplique y adjuntar evidencias antes/después si se modifican HTML o CSV.
+
+---
+
+## 🔐 Notas operativas
+
+`docs/hash_data.csv` contiene rutas absolutas y tamaños. Solo compártelo con colaboradores de confianza. Los sanitizadores bloquean protocolos externos (acestream, http); extiende la blocklist si aparecen nuevos protocolos, en vez de deshabilitarla.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,85 @@
+# 🧠 Discos-Análisis-Final
+
+Sistema de inventario interactivo y análisis multimedia multiunidad con hash, duplicados y publicación automática en GitHub Pages.
+
+---
+
+## 🚀 Quickstart
+
+**Escanear, hashear y actualizar inventario automáticamente**
+
+```pwsh
+pwsh -NoProfile -ExecutionPolicy Bypass -File tools\scan-drives-interactive.ps1
+```
+
+Esto lanzará una ventana gráfica para seleccionar las unidades que quieras analizar (ejemplo: `C:`, `D:`, `J:`) y opcionalmente marcar el cálculo de hash SHA256.
+
+### ⚙️ Flujo automático
+
+El proceso completo está totalmente automatizado:
+
+| Etapa | Descripción |
+| --- | --- |
+| 🗂️ Selección de unidades | Popup interactivo que detecta discos y permite elegir cuáles analizar |
+| 🔍 Escaneo de archivos | Busca fotos, vídeos, audios y documentos en cada unidad seleccionada |
+| 🔢 Cálculo de hash (opcional) | SHA256 para identificar duplicados y cambios |
+| 📊 Generación de inventario | Exporta resultados a `docs/hash_data.csv` (en bloques de 400 archivos) |
+| 🧩 Inyección HTML | Actualiza automáticamente `docs/inventario_interactivo_offline.html` |
+| ☁️ Sincronización | Ejecuta `tools/sync-to-github.ps1` → commit, push y rebuild de Pages |
+| 🌐 Publicación | Se abre automáticamente el inventario actualizado en tu navegador |
+
+### 🧭 Ejemplos prácticos
+
+- **Escaneo rápido sin hash**
+  ```pwsh
+  pwsh -NoProfile -ExecutionPolicy Bypass -File tools\scan-drives-interactive.ps1 -Drives "D,E" -OpenAfter
+  ```
+- **Escaneo completo con hash**
+  ```pwsh
+  pwsh -NoProfile -ExecutionPolicy Bypass -File tools\scan-drives-interactive.ps1 -Drives "C,F" -ComputeHash -OpenAfter -VerboseLog
+  ```
+- **Solo actualizar la página (sin reescanear)**
+  ```pwsh
+  pwsh -NoProfile -ExecutionPolicy Bypass -File tools\sync-to-github.ps1
+  ```
+
+---
+
+## 📂 Estructura del repositorio
+
+```
+Discos-An-lisis-Final/
+├─ docs/
+│  ├─ inventario_interactivo_offline.html   # Inventario visual (GitHub Pages)
+│  ├─ hash_data.csv                         # Datos de archivos escaneados
+│  └─ assets/                               # CSS/JS del inventario
+├─ tools/
+│  ├─ scan-drives-interactive.ps1           # Script autónomo principal
+│  ├─ inventory-inject-from-csv.ps1         # Inyector CSV → HTML
+│  ├─ sync-to-github.ps1                    # Commit + push + rebuild Pages
+│  └─ agents/                               # Herramientas auxiliares
+└─ AGENTS.md                                # Guía avanzada y ejemplos
+```
+
+### 🧩 Archivos clave
+
+| Archivo | Rol principal |
+| --- | --- |
+| `tools/scan-drives-interactive.ps1` | Escaneo y flujo completo |
+| `tools/inventory-inject-from-csv.ps1` | Inserta datos CSV en HTML |
+| `tools/sync-to-github.ps1` | Sube los cambios y fuerza rebuild |
+| `docs/hash_data.csv` | Base de datos de resultados |
+| `docs/inventario_interactivo_offline.html` | Vista interactiva final |
+| `AGENTS.md` | Documentación técnica extendida |
+
+---
+
+## 🧠 Concepto
+
+El sistema combina automatización PowerShell + GitHub Pages para crear una vista web interactiva de los archivos multimedia de tus discos, detectando duplicados, rutas, tamaños y tipos en tiempo real.
+
+## 🧰 Autor
+
+Desarrollado por **Antonio Durán Mingorance**.
+
+💡 Inspirado en la idea de un inventario multimedia universal multiplataforma y autosincronizado.


### PR DESCRIPTION
## Summary
- add a modern README that explains the autonomous inventory workflow, repository layout, and key scripts
- rewrite AGENTS.md into a quick reference playbook with architecture, commands, style, testing, and operational notes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1f6e029d0832a8463ce59f27292a0