### PR TITLE
Make picker modal optional and fully dismissible

### DIFF
--- a/docs/assets/css/picker.css
+++ b/docs/assets/css/picker.css
@@ -2,15 +2,12 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 1rem;
   padding: 0.6rem 1rem;
-  margin-bottom: 1rem;
   border-bottom: 1px solid #e5e7eb;
   background: #fff;
   position: sticky;
   top: 0;
-  z-index: 10;
-  box-shadow: 0 10px 24px -20px rgba(15, 23, 42, 0.45);
+  z-index: 100;
 }
 
 .site-header .brand {
@@ -32,91 +29,72 @@
   color: #475569;
 }
 
-.player-picker select {
-  padding: 0.35rem 0.6rem;
-  border-radius: 0.5rem;
-  border: 1px solid #d1d5db;
-  background: #f9fafb;
-  color: #0f172a;
-  font-size: 0.86rem;
-}
-
+.player-picker select,
 .player-picker button {
   padding: 0.35rem 0.6rem;
   border: 1px solid #d1d5db;
   border-radius: 0.5rem;
   background: #f9fafb;
-  color: #1f2937;
-  font-size: 0.8rem;
+  color: #0f172a;
+}
+
+.player-picker button {
   cursor: pointer;
-  transition: transform 0.15s ease, background 0.15s ease;
 }
 
 .player-picker button:hover {
   background: #f3f4f6;
-  transform: translateY(-1px);
 }
 
-/* Modal */
+.ow-modal[hidden] {
+  display: none !important;
+}
+
 .ow-modal {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.4);
-  display: grid;
-  place-items: center;
-  padding: 1.5rem;
+  z-index: 9999;
+}
+
+.ow-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
 }
 
 .ow-dialog {
   position: relative;
+  max-width: min(560px, 92vw);
+  margin: auto;
+  top: 15vh;
   background: #fff;
-  border-radius: 0.75rem;
-  min-width: 320px;
-  max-width: 90vw;
-  padding: 1rem;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
+  border-radius: 12px;
+  padding: 16px 16px 12px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
 }
 
-.ow-dialog h3 {
-  margin: 0;
+.ow-title {
+  margin: 0 0 0.25rem 0;
   font-size: 1.05rem;
-  color: #0f172a;
 }
 
-.ow-dialog p {
-  margin: 0;
-  font-size: 0.9rem;
-  color: #1f2937;
-  word-break: break-word;
-}
-
-.ow-message {
-  font-size: 0.82rem;
-  color: #b91c1c;
-  background: #fee2e2;
-  border: 1px solid #fecaca;
-  border-radius: 8px;
-  padding: 0.6rem 0.7rem;
+.ow-filename {
+  margin: 0.25rem 0 0.75rem 0;
+  word-break: break-all;
+  color: #374151;
 }
 
 .ow-actions {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 0.5rem;
-  margin: 0.75rem 0;
 }
 
 .ow-actions button {
-  padding: 0.6rem 0.9rem;
-  border-radius: 0.75rem;
-  border: 1px solid #cbd5f5;
+  border-color: #cbd5f5;
   background: #f8fafc;
   color: #0f172a;
   font-weight: 600;
-  cursor: pointer;
   text-align: left;
   transition: background 0.15s ease, transform 0.15s ease, border 0.15s ease;
 }
@@ -127,30 +105,43 @@
   transform: translateY(-1px);
 }
 
+.ow-x {
+  position: absolute;
+  right: 10px;
+  top: 10px;
+  border: 0;
+  background: #f3f4f6;
+  border-radius: 8px;
+  width: 32px;
+  height: 32px;
+  cursor: pointer;
+}
+
+.ow-x:hover {
+  background: #e5e7eb;
+}
+
+.ow-message {
+  font-size: 0.82rem;
+  color: #b91c1c;
+  background: #fee2e2;
+  border: 1px solid #fecaca;
+  border-radius: 8px;
+  padding: 0.6rem 0.7rem;
+  margin-bottom: 0.75rem;
+}
+
 .ow-actions button:focus-visible,
 .player-picker select:focus-visible,
 .player-picker button:focus-visible,
-.ow-close:focus-visible,
+.ow-x:focus-visible,
 .ow-preview-close:focus-visible {
   outline: 2px solid #2563eb;
   outline-offset: 2px;
 }
 
-.ow-close {
-  position: absolute;
-  top: 0.6rem;
-  right: 0.75rem;
-  border: none;
-  background: transparent;
-  font-size: 1.3rem;
-  line-height: 1;
-  cursor: pointer;
-  color: #64748b;
-  width: 100%;
-}
-
-.ow-close:hover {
-  color: #0f172a;
+body.ow-no-scroll {
+  overflow: hidden;
 }
 
 .ow-preview {

--- a/docs/index.html
+++ b/docs/index.html
@@ -65,25 +65,29 @@ thead input{width:100%;padding:7px 8px;border:1px solid #cbd5f5;border-radius:8p
   <div class="player-picker">
     <label for="globalPlayerSelect">Reproductor:</label>
     <select id="globalPlayerSelect">
-      <option value="auto">Auto (segun archivo)</option>
+      <option value="auto" selected>Auto (según archivo)</option>
+      <option value="choose">Elegir cada vez…</option>
       <option value="local">Este navegador</option>
-      <option value="browser-picker">Chromecast / AirPlay</option>
+      <option value="browser-picker">Chromecast / AirPlay…</option>
+      <!-- DLNA dinámicos aquí -->
     </select>
-    <button id="airplayBtn" type="button" hidden>AirPlay</button>
+    <button id="airplayBtn" hidden>AirPlay</button>
   </div>
 </header>
-<div id="openWithModal" class="ow-modal" hidden>
-  <div class="ow-dialog" role="dialog" aria-modal="true">
-    <button type="button" class="ow-close" aria-label="Cerrar">&times;</button>
-    <h3 id="owDialogTitle">Abrir con</h3>
-    <p id="owFileName"></p>
-    <div id="owMessage" class="ow-message" hidden></div>
+
+<!-- Modal “Abrir con…” -->
+<div id="openWithModal" class="ow-modal" hidden aria-hidden="true" role="dialog" aria-modal="true">
+  <div class="ow-backdrop" data-ow-close></div>
+  <div class="ow-dialog" role="document">
+    <button class="ow-x" type="button" aria-label="Cerrar" data-ow-close>✕</button>
+    <h3 class="ow-title" id="owDialogTitle">Abrir con…</h3>
+    <p id="owFileName" class="ow-filename"></p>
     <div class="ow-actions">
-      <button type="button" data-action="open-local">Este navegador</button>
-      <button type="button" data-action="browser-picker">Chromecast / AirPlay</button>
-      <button type="button" data-action="dlna" hidden>DLNA de la red</button>
-      <button type="button" data-action="new-tab">Nueva pestaña</button>
-      <button type="button" data-action="download">Descargar</button>
+      <button data-action="open-local">Este navegador</button>
+      <button data-action="browser-picker">Chromecast / AirPlay…</button>
+      <button data-action="dlna" hidden>DLNA de la red</button>
+      <button data-action="new-tab">Nueva pestaña</button>
+      <button data-action="download">Descargar</button>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- add an "Elegir cada vez…" mode in the header selector and refresh the open-with modal markup with a backdrop and dedicated close button
- restyle the modal so it stays centered, blocks background scrolling, and keeps the action buttons aligned with the new layout
- update the picker logic to only show the modal in choose mode, close it via ✕/backdrop/Escape, and fall back to local playback when forced modes cannot launch

## Testing
- Not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_68ea67dbb2c4832a89c8b69261a862ed