### PR TITLE
Remove legacy local viewer overlay

### DIFF
--- a/docs/assets/css/picker.css
+++ b/docs/assets/css/picker.css
@@ -2,15 +2,12 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 1rem;
   padding: 0.6rem 1rem;
-  margin-bottom: 1rem;
   border-bottom: 1px solid #e5e7eb;
   background: #fff;
   position: sticky;
   top: 0;
-  z-index: 10;
-  box-shadow: 0 10px 24px -20px rgba(15, 23, 42, 0.45);
+  z-index: 100;
 }
 
 .site-header .brand {
@@ -32,91 +29,72 @@
   color: #475569;
 }
 
-.player-picker select {
-  padding: 0.35rem 0.6rem;
-  border-radius: 0.5rem;
-  border: 1px solid #d1d5db;
-  background: #f9fafb;
-  color: #0f172a;
-  font-size: 0.86rem;
-}
-
+.player-picker select,
 .player-picker button {
   padding: 0.35rem 0.6rem;
   border: 1px solid #d1d5db;
   border-radius: 0.5rem;
   background: #f9fafb;
-  color: #1f2937;
-  font-size: 0.8rem;
+  color: #0f172a;
+}
+
+.player-picker button {
   cursor: pointer;
-  transition: transform 0.15s ease, background 0.15s ease;
 }
 
 .player-picker button:hover {
   background: #f3f4f6;
-  transform: translateY(-1px);
 }
 
-/* Modal */
+.ow-modal[hidden] {
+  display: none !important;
+}
+
 .ow-modal {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.4);
-  display: grid;
-  place-items: center;
-  padding: 1.5rem;
+  z-index: 9999;
+}
+
+.ow-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
 }
 
 .ow-dialog {
   position: relative;
+  max-width: min(560px, 92vw);
+  margin: auto;
+  top: 15vh;
   background: #fff;
-  border-radius: 0.75rem;
-  min-width: 320px;
-  max-width: 90vw;
-  padding: 1rem;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
+  border-radius: 12px;
+  padding: 16px 16px 12px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
 }
 
-.ow-dialog h3 {
-  margin: 0;
+.ow-title {
+  margin: 0 0 0.25rem 0;
   font-size: 1.05rem;
-  color: #0f172a;
 }
 
-.ow-dialog p {
-  margin: 0;
-  font-size: 0.9rem;
-  color: #1f2937;
-  word-break: break-word;
-}
-
-.ow-message {
-  font-size: 0.82rem;
-  color: #b91c1c;
-  background: #fee2e2;
-  border: 1px solid #fecaca;
-  border-radius: 8px;
-  padding: 0.6rem 0.7rem;
+.ow-filename {
+  margin: 0.25rem 0 0.75rem 0;
+  word-break: break-all;
+  color: #374151;
 }
 
 .ow-actions {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 0.5rem;
-  margin: 0.75rem 0;
 }
 
 .ow-actions button {
-  padding: 0.6rem 0.9rem;
-  border-radius: 0.75rem;
-  border: 1px solid #cbd5f5;
+  border-color: #cbd5f5;
   background: #f8fafc;
   color: #0f172a;
   font-weight: 600;
-  cursor: pointer;
   text-align: left;
   transition: background 0.15s ease, transform 0.15s ease, border 0.15s ease;
 }
@@ -127,107 +105,42 @@
   transform: translateY(-1px);
 }
 
+.ow-x {
+  position: absolute;
+  right: 10px;
+  top: 10px;
+  border: 0;
+  background: #f3f4f6;
+  border-radius: 8px;
+  width: 32px;
+  height: 32px;
+  cursor: pointer;
+}
+
+.ow-x:hover {
+  background: #e5e7eb;
+}
+
+.ow-message {
+  font-size: 0.82rem;
+  color: #b91c1c;
+  background: #fee2e2;
+  border: 1px solid #fecaca;
+  border-radius: 8px;
+  padding: 0.6rem 0.7rem;
+  margin-bottom: 0.75rem;
+}
+
 .ow-actions button:focus-visible,
 .player-picker select:focus-visible,
 .player-picker button:focus-visible,
-.ow-close:focus-visible,
-.ow-preview-close:focus-visible {
+.ow-x:focus-visible {
   outline: 2px solid #2563eb;
   outline-offset: 2px;
 }
 
-.ow-close {
-  position: absolute;
-  top: 0.6rem;
-  right: 0.75rem;
-  border: none;
-  background: transparent;
-  font-size: 1.3rem;
-  line-height: 1;
-  cursor: pointer;
-  color: #64748b;
-  width: 100%;
-}
-
-.ow-close:hover {
-  color: #0f172a;
-}
-
-.ow-preview {
-  position: fixed;
-  inset: 0;
-  background: rgba(15, 23, 42, 0.65);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 1.5rem;
-  z-index: 20;
-}
-
-.ow-preview-dialog {
-  width: min(960px, 95vw);
-  max-height: 90vh;
-  display: flex;
-  flex-direction: column;
-  background: #fff;
-  border-radius: 16px;
+body.ow-no-scroll {
   overflow: hidden;
-  box-shadow: 0 32px 80px -50px rgba(15, 23, 42, 0.7);
-}
-
-.ow-preview-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 0.8rem 1.1rem;
-  border-bottom: 1px solid #e2e8f0;
-}
-
-.ow-preview-header h3 {
-  margin: 0;
-  font-size: 0.98rem;
-  color: #0f172a;
-}
-
-.ow-preview-close {
-  border: none;
-  background: transparent;
-  font-size: 1.3rem;
-  line-height: 1;
-  cursor: pointer;
-  color: #64748b;
-}
-
-.ow-preview-close:hover {
-  color: #0f172a;
-}
-
-.ow-preview-body {
-  padding: 1rem;
-  overflow: auto;
-  background: #0f172a0d;
-}
-
-.ow-preview-body img,
-.ow-preview-body video,
-.ow-preview-body audio,
-.ow-preview-body iframe {
-  display: block;
-  margin: 0 auto;
-  max-width: 100%;
-  max-height: 70vh;
-  border-radius: 10px;
-  box-shadow: 0 24px 55px -40px rgba(15, 23, 42, 0.6);
-}
-
-.ow-preview-body pre {
-  background: #0f172a;
-  color: #f8fafc;
-  padding: 1rem;
-  border-radius: 10px;
-  overflow-x: auto;
-  max-height: 70vh;
-  font-size: 0.85rem;
 }
 
 @media (max-width: 720px) {

--- a/docs/index.html
+++ b/docs/index.html
@@ -65,35 +65,30 @@ thead input{width:100%;padding:7px 8px;border:1px solid #cbd5f5;border-radius:8p
   <div class="player-picker">
     <label for="globalPlayerSelect">Reproductor:</label>
     <select id="globalPlayerSelect">
-      <option value="auto">Auto (segun archivo)</option>
+      <option value="auto" selected>Auto (según archivo)</option>
+      <option value="choose">Elegir cada vez…</option>
       <option value="local">Este navegador</option>
-      <option value="browser-picker">Chromecast / AirPlay</option>
+      <option value="browser-picker">Chromecast / AirPlay…</option>
+      <!-- DLNA dinámicos aquí -->
     </select>
-    <button id="airplayBtn" type="button" hidden>AirPlay</button>
+    <button id="airplayBtn" hidden>AirPlay</button>
   </div>
 </header>
-<div id="openWithModal" class="ow-modal" hidden>
-  <div class="ow-dialog" role="dialog" aria-modal="true">
-    <button type="button" class="ow-close" aria-label="Cerrar">&times;</button>
-    <h3 id="owDialogTitle">Abrir con</h3>
-    <p id="owFileName"></p>
-    <div id="owMessage" class="ow-message" hidden></div>
+
+<!-- Modal “Abrir con…” -->
+<div id="openWithModal" class="ow-modal" hidden aria-hidden="true" role="dialog" aria-modal="true">
+  <div class="ow-backdrop" data-ow-close></div>
+  <div class="ow-dialog" role="document">
+    <button class="ow-x" type="button" aria-label="Cerrar" data-ow-close>✕</button>
+    <h3 class="ow-title" id="owDialogTitle">Abrir con…</h3>
+    <p id="owFileName" class="ow-filename"></p>
     <div class="ow-actions">
-      <button type="button" data-action="open-local">Este navegador</button>
-      <button type="button" data-action="browser-picker">Chromecast / AirPlay</button>
-      <button type="button" data-action="dlna" hidden>DLNA de la red</button>
-      <button type="button" data-action="new-tab">Nueva pestaña</button>
-      <button type="button" data-action="download">Descargar</button>
+      <button data-action="open-local">Este navegador</button>
+      <button data-action="browser-picker">Chromecast / AirPlay…</button>
+      <button data-action="dlna" hidden>DLNA de la red</button>
+      <button data-action="new-tab">Nueva pestaña</button>
+      <button data-action="download">Descargar</button>
     </div>
-  </div>
-</div>
-<div id="localViewer" class="ow-preview" hidden>
-  <div class="ow-preview-dialog" role="dialog" aria-modal="true" aria-labelledby="owViewerTitle">
-    <div class="ow-preview-header">
-      <h3 id="owViewerTitle">Vista previa</h3>
-      <button type="button" class="ow-preview-close" aria-label="Cerrar vista previa">&times;</button>
-    </div>
-    <div class="ow-preview-body" id="owPreviewBody"></div>
   </div>
 </div>
 <main>


### PR DESCRIPTION
## Summary
- remove the unused #localViewer modal markup and styles so the legacy overlay can no longer surface
- simplify the picker logic by dropping preview-specific wiring and relying on the overlay stack for Escape handling
- keep openLocal focused on its custom overlays so choosing "Este navegador" no longer leaves the old "Vista previa" layer behind

## Testing
- Not run (UI-only change)

------
https://chatgpt.com/codex/tasks/task_e_68ea67dbb2c4832a89c8b69261a862ed