### PR TITLE
Add configurable access gate and inventory view persistence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,9 @@ Mantén los scripts idempotentes y sin rutas absolutas codificadas.
 - Botón AirPlay en la cabecera sólo aparece en Safari cuando detecta destinos (`WebKitPlaybackTargetAvailabilityEvent`).
 - Selector global incluye opciones DLNA que llegan por `/devices` (HTTP o WebSocket) desde `tools/dlna-helper`.
 - El helper DLNA expone `/play` (HTTP) y espera `controlURL`, `mediaUrl`, `position` en el payload.
+- `docs/assets/js/mingomedia-config.js` controla la puerta de acceso (`access.*`) y el almacenamiento de vistas por usuario (`view.*`).
+- El store global `window.mingoInventory` expone `getState()`, `on(evento, handler)`, `setFilter()` y helpers similares; úsalo para integraciones o automatizaciones.
+- El orden y ancho de columnas, filas ocultas, alturas personalizadas y la selección se persisten en `localStorage` con prefijo `view.storagePrefix` + usuario normalizado.
 - Los overlays (`texto`, `audio`, `video`) pueden cerrarse con botón o clic fuera.
 - `data-no-intercept` en cualquier contenedor evita que el listener global abra el modal.
 
@@ -72,6 +75,7 @@ Mantén los scripts idempotentes y sin rutas absolutas codificadas.
 - Duplica `inventory.config.sample.json` a `inventory.config.json` para ajustar `publicBaseUrl`, `listenerPrefixes` y `driveMappings`.
 - El helper DLNA es opcional: si no se pasa `dlnaHelper/dlnaApi`, el UI oculta la acción.
 - Mantén el repo limpio: nada de rutas absolutas, sin efectos fuera de `RepoRoot`, logs en `logs/`.
+- Para cambiar el formulario de acceso o las listas permitidas edita `docs/assets/js/mingomedia-config.js`; no hardcodees credenciales en otros archivos.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ Inventario multimedia autoservicio con visores universales, soporte DLNA/Chromec
 - **Visor universal** (modal "Abrir con"):
   - Navegador local, Chromecast/AirPlay, DLNA, nueva pestaña y descarga directa.
   - Preferencia global guardada en `localStorage`.
+- **Acceso configurable**:
+  - `docs/assets/js/mingomedia-config.js` permite exigir correo y PIN antes de cargar el inventario.
+  - Sesiones opcionales en `localStorage` para no repetir el formulario.
 - **Visores integrados**:
   - Imagen / PDF / HTML → pestaña nueva u overlay según tipo.
   - Texto → overlay con `<pre>` + botón de descarga.
@@ -68,7 +71,39 @@ Inventario multimedia autoservicio con visores universales, soporte DLNA/Chromec
 - **Tabla**:
   - Columnas arrastrables con ancho ajustable y filtros por columna.
   - Descarga CSV del resultado filtrado y paginación configurable.
+  - Selección con casillas por fila (persistente por usuario) y contador en la barra.
   - `Ctrl/Cmd + clic` y botón medio mantienen el comportamiento nativo (sin modal).
+
+### Configuración de acceso y preferencias
+
+`docs/assets/js/mingomedia-config.js` expone dos secciones:
+
+```js
+window.MingoMediaConfig = {
+  access: {
+    enabled: true,
+    requireEmail: true,
+    requirePin: true,
+    pin: "1234",             // PIN global opcional
+    allowedEmails: ["admin@mingomedia.local"],
+    allowedDomains: ["familia.local"],
+    users: [{ email: "ana@familia.local", pin: "7777" }],
+    rememberSession: true,
+    version: "2025-10-10"
+  },
+  view: {
+    storagePrefix: "mingomedia.inventory.view",
+    defaultUser: "public"
+  }
+};
+```
+
+- **`access`** controla la puerta de entrada (correo obligatorio, PIN global o por usuario y lista blanca de dominios/correos).
+- **`view`** define la clave base usada en `localStorage` para guardar el orden de columnas, anchos, filas ocultas, alturas y selección.
+- Los datos de vista se aíslan por usuario: el correo validado se normaliza y se usa como sufijo (`<prefijo>:<usuario>`).
+- El formulario respeta `rememberSession`; si es `false` se solicitarán credenciales en cada visita.
+
+El estado de la tabla y los filtros se exponen vía `window.mingoInventory`, un store con métodos como `getState()`, `on(evento, handler)` o `setFilter(columna, valor)`, útil para integraciones futuras.
 
 ---
 

--- a/docs/assets/inventario.js
+++ b/docs/assets/inventario.js
@@ -1,134 +1,30 @@
-<<<<<<< HEAD
-﻿(()=> {
-  async function __loadFromEmbedded() {
-    const el = document.getElementById('inventory-data');
-    if (!el) return null;
-    try {
-      const txt = el.textContent?.trim() ?? '';
-      if (!txt) return [];
-      // Acepta array u objeto
-      const first = txt[0];
-      if (first === '[' || first === '{') return JSON.parse(txt);
-    } catch (e) {
-      console.warn('Embedded JSON parse error:', e);
-    }
-    return null;
-  }
-  async function __loadFromFile() {
-    // Solo intentar fetch si NO estamos en file://
-    if (location.protocol.startsWith('http')) {
-      const resp = await window.loadInventorySafe();
-    }
-    console.warn('file:// sin servidor http: no se intentará fetch de docs/data/inventory.json');
-    return [];
-  }
-  // Loader público
-  window.loadInventorySafe = async function() {
-    const emb = await __loadFromEmbedded();
-    if (emb && (Array.isArray(emb) ? emb.length : Object.keys(emb).length)) return emb;
-    return await __loadFromFile();
-  }
-})();
 (function(){
-  const $ = s=>document.querySelector(s), $$=s=>Array.from(document.querySelectorAll(s));
-  const dataBlock=$("#inventory-data"), metaBlock=$("#inventory-meta");
-  let ROWS=[]; try{ ROWS=JSON.parse(dataBlock?.textContent||"[]"); }catch{ ROWS=[]; }
-  const META = (()=>{ try{ return JSON.parse(metaBlock?.textContent||"{}"); }catch{return {}} })();
-=======
-﻿/**
- * inventario.js (auto-patched)
- * Soporta:
- * 1) JSON embebido:  <script id="inventory-data" type="application/json">…</script>
- * 2) data/inventory.json
- * 3) data/inventory.min.json
- * 4) data/inventory.json.gz (requiere que el servidor añada Content-Encoding:gzip
- *    o bien que exista window.pako.ungzip para descomprimir en cliente)
- */
-(function () {
   "use strict";
->>>>>>> main
 
-  async function tryFetchJson(url) {
-    const res = await fetch(url, { cache: "no-store" });
-    if (!res.ok) throw new Error("HTTP " + res.status + " @ " + url);
+  const scripts = [
+    "./assets/js/mingomedia-config.js",
+    "./assets/js/inventory-state.js",
+    "./assets/js/inventory-app.js"
+  ];
 
-    // Si el servidor ya descomprime (Content-Encoding:gzip), res.json() funciona.
-    // Si realmente viene .gz sin cabeceras (p.ej. http.server), necesitamos pako.
-    if (url.endsWith(".gz")) {
-      // Intenta primero como JSON "normal" (por si el server ya lo descomprimió)
-      try {
-        return await res.json();
-      } catch (_) {
-        // Intento con pako si está presente
-        if (window.pako && typeof window.pako.ungzip === "function") {
-          const buf = await res.arrayBuffer();
-          const uint = new Uint8Array(buf);
-          const text = window.pako.ungzip(uint, { to: "string" });
-          return JSON.parse(text);
-        }
-        throw new Error(
-          "El archivo " + url + " está comprimido y el servidor no envía Content-Encoding:gzip.\n" +
-          "Opciones:\n" +
-          "  a) Servirlo con cabecera Content-Encoding:gzip (nginx/Apache/Express) o\n" +
-          "  b) Incluir pako (https://github.com/nodeca/pako) antes de este script para descomprimir en cliente,\n" +
-          "  c) Usar data/inventory.json o data/inventory.min.json."
-        );
-      }
+  function loadSequential(list) {
+    if (!list.length) {
+      return;
     }
-
-    // Caso normal: JSON llano
-    return await res.json();
+    const src = list.shift();
+    const script = document.createElement("script");
+    script.src = src;
+    script.async = false;
+    script.defer = false;
+    script.onload = function() {
+      loadSequential(list);
+    };
+    script.onerror = function(error) {
+      console.error("No se pudo cargar", src, error);
+      loadSequential(list);
+    };
+    document.head.appendChild(script);
   }
 
-  async function loadInventoryData() {
-    // 1) Embebido
-    const embedded = document.getElementById("inventory-data");
-    if (embedded && embedded.textContent && embedded.textContent.trim().length > 0) {
-      console.log("📦 Cargando datos embebidos en el HTML…");
-      return JSON.parse(embedded.textContent);
-    }
-
-    // 2) Rutas externas candidatas (orden de preferencia)
-    const candidates = [
-      "data/inventory.json",
-      "data/inventory.min.json",
-      "data/inventory.json.gz"
-    ];
-
-    let lastErr = null;
-    for (const url of candidates) {
-      try {
-        console.log("🌐 Probando:", url);
-        const data = await tryFetchJson(url);
-        console.log("✅ OK:", url);
-        return data;
-      } catch (e) {
-        console.warn("⚠️ Falló", url, "→", e.message);
-        lastErr = e;
-      }
-    }
-    throw lastErr || new Error("No se pudo cargar ningún origen de datos.");
-  }
-
-  function render(data) {
-    // Usa la función de tu tabla si existe.
-    if (typeof renderInventory === "function") return renderInventory(data);
-    if (typeof buildTable === "function") return buildTable(data);
-
-    console.error("❌ No se encontró renderInventory() ni buildTable(). Ajusta aquí tu inicialización.");
-    // Ejemplo mínimo si no hay renderer:
-    // console.table(data.slice(0, 10));
-  }
-
-  document.addEventListener("DOMContentLoaded", async () => {
-    try {
-      const data = await loadInventoryData();
-      render(data);
-    } catch (err) {
-      console.error("❌ Error cargando inventario:", err);
-      alert("No se pudo cargar el inventario.\n" + err.message);
-    }
-  });
+  loadSequential(scripts.slice());
 })();
-
-

--- a/docs/assets/js/inventory-app.js
+++ b/docs/assets/js/inventory-app.js
@@ -1,0 +1,1090 @@
+(function(window, document){
+  "use strict";
+
+  const globalConfig = window.MingoMediaConfig || {};
+  const viewConfig = globalConfig.view || {};
+  const accessConfig = globalConfig.access || {};
+  const SESSION_KEY = "mingomedia.access.session";
+
+  const columns = {
+    sha: { id: "sha", label: "SHA", type: "text", className: "muted wrap", get: row => row.sha || "", filterPlaceholder: "Filtrar hash", csv: row => row.sha || "" },
+    tipo: { id: "tipo", label: "Tipo", type: "text", get: row => row.tipo || "", filterPlaceholder: "Filtrar tipo" },
+    nombre: { id: "nombre", label: "Nombre", type: "text", get: row => row.nombre || "", render: row => cellFileLink(row), filterPlaceholder: "Filtrar nombre", csv: row => row.nombre || "" },
+    ruta: { id: "ruta", label: "Ruta/Carpeta", type: "text", get: row => row.ruta || "", render: row => cellFolderLink(row), filterPlaceholder: "Filtrar ruta", csv: row => row.ruta || "" },
+    unidad: { id: "unidad", label: "Unidad", type: "text", get: row => row.unidad || "", filterPlaceholder: "Filtrar unidad" },
+    tamano: { id: "tamano", label: "Tama&ntilde;o", type: "number", className: "col-size", get: row => Number(row.tamano || 0), render: row => escapeHtml(human(row.tamano)), filterPlaceholder: ">=, <=, =", csv: row => Number(row.tamano || 0) },
+    fecha: { id: "fecha", label: "Fecha", type: "date", className: "col-date", get: row => row.fecha || "", render: row => escapeHtml(formatDate(row.fecha)), filterPlaceholder: "YYYY-MM-DD", csv: row => row.fecha || "" }
+  };
+
+  const defaultOrder = ["sha", "tipo", "nombre", "ruta", "unidad", "tamano", "fecha"];
+  const defaultWidths = { sha: 240, tipo: 120, nombre: 260, ruta: 320, unidad: 90, tamano: 130, fecha: 160 };
+
+  const store = window.createMingoInventoryStore({
+    allColumns: Object.keys(columns),
+    defaultOrder,
+    defaultWidths,
+    storagePrefix: viewConfig.storagePrefix || "mingomedia.inventory.view",
+    defaultUserKey: viewConfig.defaultUser || "public",
+    initialPageSize: 50
+  });
+
+  window.mingoInventory = store;
+
+  const elements = {
+    err: document.getElementById("err"),
+    tableShell: document.getElementById("tableShell"),
+    headerRow: document.getElementById("headerRow"),
+    filterRow: document.getElementById("filterRow"),
+    tbody: document.querySelector("#tbl tbody"),
+    q: document.getElementById("q"),
+    chips: document.getElementById("unitChips"),
+    count: document.getElementById("count"),
+    size: document.getElementById("size"),
+    pageSize: document.getElementById("pageSize"),
+    prev: document.getElementById("prevPage"),
+    next: document.getElementById("nextPage"),
+    pageInfo: document.getElementById("pageInfo"),
+    download: document.getElementById("downloadBtn"),
+    resetCols: document.getElementById("resetColumns"),
+    unitSummary: document.getElementById("unitSummary"),
+    extSummary: document.getElementById("extSummary"),
+    pathSummary: document.getElementById("pathSummary"),
+    selectionIndicator: document.getElementById("selectionIndicator"),
+    selectionCount: document.getElementById("selectionCount"),
+    accessGate: document.getElementById("accessGate"),
+    accessMessage: document.getElementById("accessMessage"),
+    accessForm: document.getElementById("accessForm"),
+    accessEmail: document.getElementById("accessEmail"),
+    accessPin: document.getElementById("accessPin"),
+    accessPinLabel: document.getElementById("accessPinLabel"),
+    accessError: document.getElementById("accessError"),
+    accessSubmit: document.getElementById("accessSubmit")
+  };
+
+  const baseNode = document.getElementById("INV_B64");
+  let DATA = [];
+  const rowLookup = new Map();
+  let selectAllCheckbox = null;
+  let dragSource = null;
+  let renderPending = false;
+  let lastRenderedRowIds = [];
+
+  ensureInventoryLoader();
+
+  document.addEventListener("DOMContentLoaded", () => {
+    setupStoreListeners();
+    buildHeaders();
+    ensureAccess(accessConfig).then(session => {
+      const fallbackUser = viewConfig.defaultUser || "public";
+      const userKey = session && session.userKey ? session.userKey : (session && session.email ? session.email : null);
+      store.setUser(userKey || fallbackUser);
+      loadInventory().catch(showErr);
+    }).catch(showErr);
+    wireUi();
+  });
+
+  function ensureInventoryLoader() {
+    if (typeof window.loadInventorySafe === "function") {
+      return;
+    }
+    window.loadInventorySafe = async function loadInventorySafe() {
+      const embedded = await loadFromEmbedded();
+      if (embedded && embedded.length) {
+        return embedded;
+      }
+      return await loadFromFile();
+    };
+  }
+
+  async function loadFromEmbedded() {
+    if (!baseNode) {
+      return null;
+    }
+    const raw = (baseNode.textContent || "").trim();
+    if (!raw) {
+      return null;
+    }
+    try {
+      const decoded = decodeBase64(raw);
+      if (Array.isArray(decoded) && decoded.length) {
+        return decoded;
+      }
+      if (decoded && typeof decoded === "object" && Array.isArray(decoded.data)) {
+        return decoded.data;
+      }
+      return Array.isArray(decoded) ? decoded : [];
+    } catch (error) {
+      console.warn("Error leyendo inventario embebido", error);
+      return null;
+    }
+  }
+
+  async function loadFromFile() {
+    const src = baseNode ? baseNode.getAttribute("data-src") : null;
+    const candidates = [];
+    if (src) {
+      candidates.push(src);
+    }
+    candidates.push("data/inventory.json", "data/inventory.min.json", "data/inventory.json.gz");
+
+    let lastError = null;
+    for (const url of candidates) {
+      if (!url) { continue; }
+      try {
+        const data = await fetchJson(url);
+        return Array.isArray(data) ? data : (data && Array.isArray(data.data) ? data.data : []);
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    if (lastError) {
+      throw lastError;
+    }
+    throw new Error("No se pudo cargar el inventario");
+  }
+
+  async function fetchJson(url) {
+    if (!url) {
+      throw new Error("URL de inventario no definida");
+    }
+    const protocol = (window.location && window.location.protocol) || "";
+    if (!protocol.startsWith("http") && url.startsWith("data/")) {
+      throw new Error("No se puede hacer fetch sin servidor HTTP");
+    }
+    const res = await fetch(url, { cache: "no-store" });
+    if (!res.ok) {
+      throw new Error("No se pudo cargar " + url + " (" + res.status + ")");
+    }
+    if (url.endsWith(".gz")) {
+      try {
+        return await res.json();
+      } catch (_) {
+        if (window.pako && typeof window.pako.ungzip === "function") {
+          const buf = await res.arrayBuffer();
+          const text = window.pako.ungzip(new Uint8Array(buf), { to: "string" });
+          return JSON.parse(text);
+        }
+        throw new Error("El archivo " + url + " está comprimido y no se pudo descomprimir.");
+      }
+    }
+    return await res.json();
+  }
+
+  function decodeBase64(raw) {
+    const bin = window.atob(raw);
+    const bytes = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) {
+      bytes[i] = bin.charCodeAt(i);
+    }
+    const txt = new TextDecoder("utf-8", { fatal: false }).decode(bytes);
+    return JSON.parse(txt);
+  }
+
+  async function loadInventory() {
+    try {
+      const raw = await window.loadInventorySafe();
+      DATA = normalizeData(raw);
+      DATA.forEach(rememberRow);
+      requestRender();
+    } catch (error) {
+      showErr(error);
+    }
+  }
+
+  function normalizeData(source) {
+    return (Array.isArray(source) ? source : []).map(row => ({
+      sha: row.sha || "",
+      tipo: row.tipo || row.type || "",
+      nombre: row.nombre || row.name || "",
+      ruta: row.ruta || row.dir || row.path || "",
+      unidad: (row.unidad || row.drive || "").toString().trim(),
+      tamano: Number((row.tamano ?? row.size ?? row.length) || 0),
+      fecha: row.fecha || row.date || row.lastWriteTime || ""
+    }));
+  }
+
+  function rememberRow(row) {
+    const id = getRowId(row);
+    if (id) {
+      rowLookup.set(id, row);
+    }
+  }
+
+  function showErr(err) {
+    const msg = err && err.message ? err.message : String(err);
+    if (elements.err) {
+      elements.err.textContent = "[!] " + msg;
+      elements.err.style.display = "block";
+    }
+    console.error(msg);
+  }
+  function setupStoreListeners() {
+    store.on("columns:order", () => {
+      buildHeaders();
+    });
+    store.on("columns:hidden", () => {
+      buildHeaders();
+    });
+    store.on("view:hydrate", () => {
+      buildHeaders();
+      syncFilterInputs();
+    });
+    store.on("filters:change", () => {
+      syncFilterInputs();
+    });
+    store.on("change", () => {
+      requestRender();
+    });
+  }
+
+  function requestRender() {
+    if (renderPending) {
+      return;
+    }
+    renderPending = true;
+    window.requestAnimationFrame(() => {
+      renderPending = false;
+      render();
+    });
+  }
+
+  function buildHeaders() {
+    if (!elements.headerRow || !elements.filterRow) {
+      return;
+    }
+    const snapshot = store.getState();
+    const hidden = new Set(snapshot.hiddenColumns || []);
+
+    elements.headerRow.innerHTML = "";
+    elements.filterRow.innerHTML = "";
+
+    const selectorHeader = document.createElement("th");
+    selectorHeader.className = "selector-header";
+    const selectorCheckbox = document.createElement("input");
+    selectorCheckbox.type = "checkbox";
+    selectorCheckbox.addEventListener("change", event => {
+      handleSelectAll(event.target.checked);
+    });
+    selectorHeader.appendChild(selectorCheckbox);
+    selectAllCheckbox = selectorCheckbox;
+    elements.headerRow.appendChild(selectorHeader);
+
+    const selectorFilter = document.createElement("th");
+    selectorFilter.className = "selector-header";
+    elements.filterRow.appendChild(selectorFilter);
+
+    snapshot.order.forEach(colId => {
+      if (hidden.has(colId)) {
+        return;
+      }
+      const col = columns[colId];
+      if (!col) {
+        return;
+      }
+      const th = document.createElement("th");
+      th.dataset.col = colId;
+      th.draggable = true;
+      const width = snapshot.widths[colId] || defaultWidths[colId] || 150;
+      th.style.width = width + "px";
+      const wrapper = document.createElement("div");
+      wrapper.className = "th-content";
+      const label = document.createElement("span");
+      label.className = "th-label";
+      label.innerHTML = col.label;
+      wrapper.appendChild(label);
+      th.appendChild(wrapper);
+      const handle = document.createElement("span");
+      handle.className = "resize-handle";
+      th.appendChild(handle);
+
+      handle.addEventListener("pointerdown", event => {
+        event.preventDefault();
+        event.stopPropagation();
+        const startX = event.clientX;
+        const startWidth = th.getBoundingClientRect().width;
+        function onMove(moveEvent) {
+          const delta = moveEvent.clientX - startX;
+          const newWidth = Math.max(80, startWidth + delta);
+          th.style.width = newWidth + "px";
+        }
+        function onUp(moveEvent) {
+          window.removeEventListener("pointermove", onMove);
+          window.removeEventListener("pointerup", onUp);
+          const delta = moveEvent.clientX - startX;
+          const newWidth = Math.max(80, startWidth + delta);
+          store.setColumnWidth(colId, newWidth);
+        }
+        window.addEventListener("pointermove", onMove);
+        window.addEventListener("pointerup", onUp, { once: true });
+      });
+
+      th.addEventListener("dragstart", event => {
+        dragSource = colId;
+        th.classList.add("drag-source");
+        if (elements.tableShell) {
+          elements.tableShell.classList.add("drag-active");
+        }
+        try {
+          event.dataTransfer.effectAllowed = "move";
+          event.dataTransfer.setData("text/plain", colId);
+        } catch (_) {
+          /* ignore */
+        }
+      });
+      th.addEventListener("dragend", () => {
+        dragSource = null;
+        th.classList.remove("drag-source");
+        if (elements.tableShell) {
+          elements.tableShell.classList.remove("drag-active");
+        }
+        Array.from(elements.headerRow.children).forEach(node => node.classList.remove("drop-target"));
+      });
+      th.addEventListener("dragover", event => {
+        event.preventDefault();
+        if (!dragSource || dragSource === colId) {
+          return;
+        }
+        th.classList.add("drop-target");
+      });
+      th.addEventListener("dragleave", () => {
+        th.classList.remove("drop-target");
+      });
+      th.addEventListener("drop", event => {
+        event.preventDefault();
+        th.classList.remove("drop-target");
+        if (!dragSource || dragSource === colId) {
+          return;
+        }
+        const current = store.getState().order.slice();
+        const fromIdx = current.indexOf(dragSource);
+        const toIdx = current.indexOf(colId);
+        if (fromIdx === -1 || toIdx === -1) {
+          return;
+        }
+        current.splice(fromIdx, 1);
+        current.splice(toIdx, 0, dragSource);
+        store.setColumnOrder(current);
+      });
+
+      elements.headerRow.appendChild(th);
+
+      const filterCell = document.createElement("th");
+      let placeholder = "Filtrar";
+      if (col.type === "number") {
+        placeholder = ">=, <=, =";
+      } else if (col.type === "date") {
+        placeholder = "YYYY-MM-DD";
+      } else if (col.filterPlaceholder) {
+        placeholder = col.filterPlaceholder;
+      }
+      const input = document.createElement("input");
+      input.setAttribute("data-col", colId);
+      input.placeholder = placeholder;
+      input.value = snapshot.filters[colId] || "";
+      input.addEventListener("input", ev => {
+        store.setFilter(colId, ev.target.value);
+      });
+      filterCell.appendChild(input);
+      elements.filterRow.appendChild(filterCell);
+    });
+
+    syncSelectAllCheckbox(snapshot);
+  }
+
+  function syncFilterInputs() {
+    const snapshot = store.getState();
+    if (!elements.filterRow) {
+      return;
+    }
+    const inputs = elements.filterRow.querySelectorAll("input[data-col]");
+    inputs.forEach(input => {
+      const colId = input.getAttribute("data-col");
+      input.value = snapshot.filters[colId] || "";
+    });
+  }
+
+  function wireUi() {
+    if (elements.q) {
+      elements.q.addEventListener("input", event => {
+        store.setSearch(event.target.value);
+      });
+    }
+    if (elements.pageSize) {
+      elements.pageSize.addEventListener("change", event => {
+        store.setPageSize(Number(event.target.value));
+      });
+    }
+    if (elements.prev) {
+      elements.prev.addEventListener("click", () => {
+        const state = store.getState();
+        if (state.page > 1) {
+          store.setPage(state.page - 1);
+        }
+      });
+    }
+    if (elements.next) {
+      elements.next.addEventListener("click", () => {
+        const state = store.getState();
+        store.setPage(state.page + 1);
+      });
+    }
+    if (elements.download) {
+      elements.download.addEventListener("click", () => {
+        const snapshot = store.getState();
+        downloadCsv(applyFilters(snapshot, false), snapshot);
+      });
+    }
+    if (elements.resetCols) {
+      elements.resetCols.addEventListener("click", () => {
+        store.resetColumns();
+      });
+    }
+  }
+  function ensureAccess(config) {
+    return new Promise((resolve) => {
+      if (!elements.accessGate || !elements.accessForm) {
+        resolve({ email: null });
+        return;
+      }
+      if (!config || config.enabled === false) {
+        elements.accessGate.hidden = true;
+        resolve({ email: null });
+        return;
+      }
+
+      const existing = loadSession(config);
+      if (existing) {
+        elements.accessGate.hidden = true;
+        resolve(existing);
+        return;
+      }
+
+      if (elements.accessMessage) {
+        elements.accessMessage.textContent = config.message || "Introduce tu correo para continuar.";
+      }
+      setupAccessForm(config, resolve);
+    });
+  }
+
+  function setupAccessForm(config, resolve) {
+    elements.accessGate.hidden = false;
+    if (elements.accessError) {
+      elements.accessError.hidden = true;
+      elements.accessError.textContent = "";
+    }
+
+    const requireEmail = config.requireEmail !== false;
+    if (elements.accessEmail) {
+      if (requireEmail) {
+        elements.accessEmail.setAttribute("required", "required");
+      } else {
+        elements.accessEmail.removeAttribute("required");
+      }
+    }
+
+    updatePinField(config, elements.accessEmail ? elements.accessEmail.value : "");
+
+    const onInput = () => {
+      updatePinField(config, elements.accessEmail ? elements.accessEmail.value : "");
+      if (elements.accessError) {
+        elements.accessError.hidden = true;
+      }
+    };
+
+    if (elements.accessEmail) {
+      elements.accessEmail.addEventListener("input", onInput);
+    }
+
+    const submitHandler = event => {
+      event.preventDefault();
+      if (elements.accessEmail) {
+        elements.accessEmail.removeEventListener("input", onInput);
+      }
+      const emailRaw = elements.accessEmail ? String(elements.accessEmail.value || "").trim() : "";
+      const pinRaw = elements.accessPin ? String(elements.accessPin.value || "").trim() : "";
+      const validation = validateCredentials(config, emailRaw, pinRaw);
+      if (!validation.ok) {
+        if (elements.accessError) {
+          elements.accessError.hidden = false;
+          elements.accessError.textContent = validation.message;
+        }
+        if (validation.focus === "email" && elements.accessEmail) {
+          elements.accessEmail.focus();
+        } else if (validation.focus === "pin" && elements.accessPin) {
+          elements.accessPin.focus();
+        }
+        elements.accessForm.addEventListener("submit", submitHandler, { once: true });
+        if (elements.accessEmail) {
+          elements.accessEmail.addEventListener("input", onInput);
+        }
+        return;
+      }
+
+      const session = { email: validation.email || null, userKey: validation.userKey || null };
+      if (config.rememberSession !== false) {
+        saveSession(config, session.email);
+      }
+      elements.accessGate.hidden = true;
+      resolve(session);
+    };
+
+    elements.accessForm.addEventListener("submit", submitHandler, { once: true });
+  }
+
+  function loadSession(config) {
+    try {
+      const raw = window.localStorage.getItem(SESSION_KEY);
+      if (!raw) {
+        return null;
+      }
+      const saved = JSON.parse(raw);
+      if (!saved || typeof saved !== "object") {
+        return null;
+      }
+      if (config.version && saved.version !== config.version) {
+        return null;
+      }
+      const email = saved.email ? String(saved.email).trim() : "";
+      if (!email || !validateEmail(email)) {
+        return null;
+      }
+      if (!emailAllowed(config, email)) {
+        return null;
+      }
+      return { email, userKey: normalizeUser(email), remembered: true };
+    } catch (error) {
+      console.warn("No se pudo recuperar la sesión", error);
+      return null;
+    }
+  }
+
+  function saveSession(config, email) {
+    const payload = { email: email || "", version: config.version || null };
+    try {
+      window.localStorage.setItem(SESSION_KEY, JSON.stringify(payload));
+    } catch (error) {
+      console.warn("No se pudo almacenar la sesión", error);
+    }
+  }
+
+  function updatePinField(config, email) {
+    const requirement = pinRequirement(config, email);
+    if (!elements.accessPinLabel) {
+      return;
+    }
+    const shouldShow = requirement.required || Boolean(requirement.expectedPin);
+    elements.accessPinLabel.hidden = !shouldShow;
+    if (!elements.accessPin) {
+      return;
+    }
+    elements.accessPin.value = "";
+    if (requirement.required) {
+      elements.accessPin.setAttribute("required", "required");
+    } else {
+      elements.accessPin.removeAttribute("required");
+    }
+  }
+
+  function validateCredentials(config, email, pin) {
+    const requireEmail = config.requireEmail !== false;
+    if (requireEmail && !email) {
+      return { ok: false, message: "El correo es obligatorio", focus: "email" };
+    }
+    if (email && !validateEmail(email)) {
+      return { ok: false, message: "Formato de correo no válido", focus: "email" };
+    }
+    if (email && !emailAllowed(config, email)) {
+      return { ok: false, message: "Correo no autorizado", focus: "email" };
+    }
+
+    const requirement = pinRequirement(config, email);
+    if (requirement.required && !pin) {
+      return { ok: false, message: "Introduce el PIN", focus: "pin" };
+    }
+    if (requirement.expectedPin) {
+      if (!pin) {
+        return { ok: false, message: "Introduce el PIN", focus: "pin" };
+      }
+      if (pin !== requirement.expectedPin) {
+        return { ok: false, message: "PIN incorrecto", focus: "pin" };
+      }
+    }
+
+    return { ok: true, email: email || null, userKey: email ? normalizeUser(email) : null };
+  }
+
+  function pinRequirement(config, email) {
+    const normalizedEmail = email ? email.toLowerCase().trim() : "";
+    const users = Array.isArray(config.users) ? config.users : [];
+    const userEntry = users.find(user => user && typeof user === "object" && user.email && String(user.email).toLowerCase().trim() === normalizedEmail);
+    const userPin = userEntry && userEntry.pin !== undefined && userEntry.pin !== null ? String(userEntry.pin).trim() : "";
+    const globalPin = config.pin !== undefined && config.pin !== null ? String(config.pin).trim() : "";
+    const requirePin = config.requirePin === true;
+    if (userPin) {
+      return { required: true, expectedPin: userPin };
+    }
+    if (requirePin && globalPin) {
+      return { required: true, expectedPin: globalPin };
+    }
+    if (requirePin) {
+      return { required: true, expectedPin: "" };
+    }
+    if (globalPin) {
+      return { required: false, expectedPin: globalPin };
+    }
+    return { required: false, expectedPin: "" };
+  }
+
+  function emailAllowed(config, email) {
+    const normalized = email ? email.toLowerCase().trim() : "";
+    const allowedEmails = Array.isArray(config.allowedEmails) ? config.allowedEmails.map(e => String(e).toLowerCase().trim()) : [];
+    const allowedDomains = Array.isArray(config.allowedDomains) ? config.allowedDomains.map(e => String(e).toLowerCase().trim()) : [];
+    const users = Array.isArray(config.users) ? config.users : [];
+    if (!allowedEmails.length && !allowedDomains.length && !users.length) {
+      return true;
+    }
+    if (allowedEmails.includes(normalized)) {
+      return true;
+    }
+    if (users.some(user => user && user.email && String(user.email).toLowerCase().trim() === normalized)) {
+      return true;
+    }
+    if (allowedDomains.length) {
+      const domain = normalized.split("@")[1] || "";
+      if (domain && allowedDomains.includes(domain)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function validateEmail(email) {
+    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+  }
+
+  function normalizeUser(email) {
+    return email ? email.trim().toLowerCase().replace(/[^a-z0-9_.@-]+/g, "_") : null;
+  }
+  function handleSelectAll(checked) {
+    if (!lastRenderedRowIds.length) {
+      if (!checked) {
+        store.clearSelection();
+      }
+      return;
+    }
+    if (checked) {
+      store.updateSelection({ add: lastRenderedRowIds });
+    } else {
+      store.updateSelection({ remove: lastRenderedRowIds });
+    }
+  }
+
+  function render() {
+    const snapshot = store.getState();
+    const filteredWithoutUnit = applyFilters(snapshot, true);
+    const filtered = applyFilters(snapshot, false);
+    const bytes = computeBytes(filtered);
+    renderChips(filteredWithoutUnit, snapshot);
+    renderInsights(filtered);
+    const pageInfo = getCurrentSlice(filtered, snapshot);
+    lastRenderedRowIds = pageInfo.rows.map(getRowId);
+    renderTableBody(pageInfo.rows, snapshot);
+    renderSummary(filtered.length, bytes, snapshot, pageInfo);
+    syncSelectAllCheckbox(snapshot);
+    if (elements.download) {
+      elements.download.disabled = filtered.length === 0;
+    }
+  }
+
+  function applyFilters(snapshot, skipUnit) {
+    const searchTerm = (snapshot.search || "").toLowerCase();
+    const hasSearch = searchTerm.length > 0;
+    const filters = snapshot.filters || {};
+    const hiddenRows = new Set(snapshot.hiddenRows || []);
+    return DATA.filter(row => {
+      const rowId = getRowId(row);
+      if (hiddenRows.has(rowId)) {
+        return false;
+      }
+      if (!skipUnit && snapshot.activeUnit && row.unidad !== snapshot.activeUnit) {
+        return false;
+      }
+      if (hasSearch) {
+        const hay = (row.nombre + " " + row.ruta + " " + row.sha + " " + row.tipo + " " + row.unidad).toLowerCase();
+        if (!hay.includes(searchTerm)) {
+          return false;
+        }
+      }
+      for (const key in filters) {
+        if (!Object.prototype.hasOwnProperty.call(filters, key)) {
+          continue;
+        }
+        const raw = filters[key];
+        if (!raw) {
+          continue;
+        }
+        if (key === "tamano") {
+          const match = raw.match(/^\s*(>=|<=|=)\s*(\d+)\s*$/);
+          const current = Number(row.tamano || 0);
+          if (match) {
+            const op = match[1];
+            const val = Number(match[2]);
+            if (op === ">=" && !(current >= val)) { return false; }
+            if (op === "<=" && !(current <= val)) { return false; }
+            if (op === "=" && current !== val) { return false; }
+          } else {
+            if (human(current).toLowerCase().indexOf(raw.toLowerCase()) === -1) {
+              return false;
+            }
+          }
+        } else if (key === "fecha") {
+          if (!(row.fecha || "").toLowerCase().startsWith(raw.toLowerCase())) {
+            return false;
+          }
+        } else {
+          const compare = (row[key] || "").toString().toLowerCase();
+          if (!compare.includes(raw.toLowerCase())) {
+            return false;
+          }
+        }
+      }
+      return true;
+    });
+  }
+
+  function renderChips(rows, snapshot) {
+    if (!elements.chips) {
+      return;
+    }
+    elements.chips.innerHTML = "";
+    const counts = new Map();
+    rows.forEach(row => {
+      if (!row.unidad) {
+        return;
+      }
+      counts.set(row.unidad, (counts.get(row.unidad) || 0) + 1);
+    });
+    const allBtn = document.createElement("button");
+    allBtn.textContent = "Todas (" + rows.length + ")";
+    allBtn.className = "chip-all";
+    allBtn.dataset.active = snapshot.activeUnit === "" ? "true" : "false";
+    allBtn.addEventListener("click", () => {
+      store.setActiveUnit("");
+    });
+    elements.chips.appendChild(allBtn);
+    const entries = Array.from(counts.entries());
+    if (snapshot.activeUnit && !counts.has(snapshot.activeUnit)) {
+      entries.push([snapshot.activeUnit, 0]);
+    }
+    entries.sort((a, b) => a[0].localeCompare(b[0], undefined, { numeric: true, sensitivity: "base" })).forEach(entry => {
+      const btn = document.createElement("button");
+      btn.textContent = entry[0] + " (" + entry[1] + ")";
+      btn.dataset.unit = entry[0];
+      btn.dataset.active = snapshot.activeUnit === entry[0] ? "true" : "false";
+      btn.addEventListener("click", () => {
+        store.setActiveUnit(snapshot.activeUnit === entry[0] ? "" : entry[0]);
+      });
+      elements.chips.appendChild(btn);
+    });
+  }
+
+  function renderTableBody(rows, snapshot) {
+    if (!elements.tbody) {
+      return;
+    }
+    elements.tbody.innerHTML = "";
+    const hiddenCols = new Set(snapshot.hiddenColumns || []);
+    const selected = new Set(snapshot.selectedRows || []);
+    const fragment = document.createDocumentFragment();
+
+    rows.forEach(row => {
+      const tr = document.createElement("tr");
+      const rowId = getRowId(row);
+      if (selected.has(rowId)) {
+        tr.classList.add("row-selected");
+      }
+      if (snapshot.rowHeights && snapshot.rowHeights[rowId]) {
+        tr.style.height = snapshot.rowHeights[rowId] + "px";
+      }
+
+      const selectorCell = document.createElement("td");
+      selectorCell.className = "row-selector-cell";
+      const checkbox = document.createElement("input");
+      checkbox.type = "checkbox";
+      checkbox.checked = selected.has(rowId);
+      checkbox.addEventListener("change", event => {
+        event.stopPropagation();
+        store.toggleRowSelection(rowId, event.target.checked);
+      });
+      selectorCell.appendChild(checkbox);
+      tr.appendChild(selectorCell);
+
+      tr.addEventListener("click", event => {
+        if (event.target && event.target.closest("a")) {
+          return;
+        }
+        store.toggleRowSelection(rowId);
+      });
+
+      snapshot.order.forEach(colId => {
+        if (hiddenCols.has(colId)) {
+          return;
+        }
+        const col = columns[colId];
+        if (!col) {
+          return;
+        }
+        const td = document.createElement("td");
+        if (col.className) {
+          td.className = col.className;
+        }
+        if (col.render) {
+          td.innerHTML = col.render(row);
+        } else if (col.get) {
+          td.textContent = col.get(row);
+        } else {
+          td.textContent = row[colId] || "";
+        }
+        tr.appendChild(td);
+      });
+
+      fragment.appendChild(tr);
+    });
+
+    elements.tbody.appendChild(fragment);
+  }
+
+  function renderSummary(totalRows, totalBytes, snapshot, pageInfo) {
+    if (elements.count) {
+      elements.count.textContent = totalRows.toLocaleString("es-ES");
+    }
+    if (elements.size) {
+      elements.size.textContent = human(totalBytes);
+    }
+    const perPage = snapshot.pageSize;
+    const totalPages = pageInfo.totalPages;
+    const currentPage = pageInfo.page;
+    if (elements.pageInfo) {
+      if (totalRows === 0) {
+        elements.pageInfo.textContent = "Sin resultados";
+      } else {
+        const start = perPage === 0 ? 1 : ((currentPage - 1) * perPage) + 1;
+        const end = perPage === 0 ? totalRows : Math.min(totalRows, currentPage * perPage);
+        elements.pageInfo.textContent = `Mostrando ${start.toLocaleString("es-ES")} - ${end.toLocaleString("es-ES")} de ${totalRows.toLocaleString("es-ES")}`;
+      }
+    }
+    if (elements.prev) {
+      elements.prev.disabled = currentPage <= 1;
+    }
+    if (elements.next) {
+      elements.next.disabled = currentPage >= totalPages;
+    }
+    if (elements.selectionIndicator && elements.selectionCount) {
+      const selectedCount = (snapshot.selectedRows || []).length;
+      if (selectedCount > 0) {
+        elements.selectionIndicator.hidden = false;
+        elements.selectionCount.textContent = selectedCount.toLocaleString("es-ES");
+      } else {
+        elements.selectionIndicator.hidden = true;
+      }
+    }
+  }
+
+  function renderInsights(rows) {
+    if (!elements.unitSummary || !elements.extSummary || !elements.pathSummary) {
+      return;
+    }
+    const empty = "<li class=\"muted\">Sin datos</li>";
+    elements.unitSummary.innerHTML = empty;
+    elements.extSummary.innerHTML = empty;
+    elements.pathSummary.innerHTML = empty;
+    if (!rows.length) {
+      return;
+    }
+
+    const byUnit = new Map();
+    const byExt = new Map();
+    const byPath = new Map();
+
+    rows.forEach(row => {
+      const unit = (row.unidad || "(sin unidad)").toString();
+      const unitStats = byUnit.get(unit) || { count: 0, size: 0 };
+      unitStats.count += 1;
+      unitStats.size += Number(row.tamano || 0);
+      byUnit.set(unit, unitStats);
+
+      const name = row.nombre || "";
+      const ext = name.includes(".") ? name.split(".").pop().toLowerCase() : "(sin extensión)";
+      const extStats = byExt.get(ext) || { count: 0 };
+      extStats.count += 1;
+      byExt.set(ext, extStats);
+
+      const path = (row.ruta || "(sin ruta)").toString();
+      const pathStats = byPath.get(path) || { count: 0 };
+      pathStats.count += 1;
+      byPath.set(path, pathStats);
+    });
+
+    elements.unitSummary.innerHTML = Array.from(byUnit.entries()).sort((a, b) => b[1].count - a[1].count || b[1].size - a[1].size).slice(0, 6).map(entry => {
+      return "<li>" + escapeHtml(entry[0]) + ": " + entry[1].count.toLocaleString("es-ES") + " archivos (" + escapeHtml(human(entry[1].size)) + ")</li>";
+    }).join("") || empty;
+
+    elements.extSummary.innerHTML = Array.from(byExt.entries()).sort((a, b) => b[1].count - a[1].count).slice(0, 6).map(entry => {
+      return "<li>" + escapeHtml(entry[0]) + ": " + entry[1].count.toLocaleString("es-ES") + " archivos</li>";
+    }).join("") || empty;
+
+    elements.pathSummary.innerHTML = Array.from(byPath.entries()).sort((a, b) => b[1].count - a[1].count).slice(0, 6).map(entry => {
+      return "<li>" + escapeHtml(entry[0]) + ": " + entry[1].count.toLocaleString("es-ES") + " archivos</li>";
+    }).join("") || empty;
+  }
+
+  function computeBytes(rows) {
+    return rows.reduce((sum, row) => sum + Number(row.tamano || 0), 0);
+  }
+
+  function getCurrentSlice(rows, snapshot) {
+    const perPage = snapshot.pageSize;
+    if (perPage === 0) {
+      return { rows: rows.slice(), page: 1, totalPages: 1 };
+    }
+    const totalPages = Math.max(1, Math.ceil(rows.length / perPage));
+    const safePage = Math.min(snapshot.page, totalPages);
+    if (safePage !== snapshot.page) {
+      store.setPage(safePage);
+    }
+    const start = (safePage - 1) * perPage;
+    return { rows: rows.slice(start, start + perPage), page: safePage, totalPages };
+  }
+
+  function syncSelectAllCheckbox(snapshot) {
+    if (!selectAllCheckbox) {
+      return;
+    }
+    if (!lastRenderedRowIds.length) {
+      selectAllCheckbox.checked = false;
+      selectAllCheckbox.indeterminate = false;
+      return;
+    }
+    const selected = new Set(snapshot.selectedRows || []);
+    const onPage = lastRenderedRowIds.filter(id => selected.has(id));
+    selectAllCheckbox.checked = onPage.length === lastRenderedRowIds.length && onPage.length > 0;
+    selectAllCheckbox.indeterminate = onPage.length > 0 && onPage.length < lastRenderedRowIds.length;
+  }
+  function getRowId(row) {
+    if (!row) {
+      return "";
+    }
+    if (row.sha) {
+      return String(row.sha);
+    }
+    const ruta = (row.ruta || "").toString();
+    const nombre = (row.nombre || "").toString();
+    const size = Number(row.tamano || 0);
+    return `${ruta}::${nombre}::${size}`;
+  }
+
+  function joinWinPath(dir, name) {
+    if (!dir) {
+      return name || "";
+    }
+    if (!name) {
+      return dir;
+    }
+    const sep = (dir.endsWith("\\") || dir.endsWith("/")) ? "" : "\\";
+    return dir + sep + name;
+  }
+
+  function toFileUrl(path) {
+    if (!path) {
+      return "";
+    }
+    let normalized = path.replace(/\\/g, "/").replace(/^\.\/+/, "");
+    const driveMatch = normalized.match(/^([A-Za-z]):\/?(.*)$/);
+    let prefix = "file:///";
+    let rest = normalized;
+    if (driveMatch) {
+      prefix += driveMatch[1].toUpperCase() + ":/";
+      rest = driveMatch[2];
+    }
+    const encoded = rest.split("/").filter(Boolean).map(part => encodeURIComponent(part)).join("/");
+    return prefix + encoded;
+  }
+
+  function cellFileLink(row) {
+    const full = joinWinPath(row.ruta, row.nombre);
+    const url = toFileUrl(full);
+    const label = escapeHtml(row.nombre || "");
+    if (!url) {
+      return label;
+    }
+    return `<a class="cell-link" href="${url}" title="Abrir archivo" target="_blank" rel="noopener">${label}</a>`;
+  }
+
+  function cellFolderLink(row) {
+    const url = toFileUrl(row.ruta || "");
+    const label = escapeHtml(row.ruta || "");
+    if (!url) {
+      return label;
+    }
+    return `<a class="cell-link" href="${url}" title="Abrir carpeta" target="_blank" rel="noopener">${label}</a>`;
+  }
+
+  function human(bytes) {
+    if (!bytes || Number.isNaN(bytes)) {
+      return "0 B";
+    }
+    const units = ["B", "KB", "MB", "GB", "TB", "PB"];
+    let value = Number(bytes);
+    let idx = 0;
+    while (value >= 1024 && idx < units.length - 1) {
+      value /= 1024;
+      idx += 1;
+    }
+    return value.toFixed(idx === 0 ? 0 : 1) + " " + units[idx];
+  }
+
+  function formatDate(value) {
+    return value ? value.replace("T", " ").replace("Z", "") : "";
+  }
+
+  function escapeHtml(text) {
+    return (text ?? "").toString().replace(/[&<>\"]/g, ch => {
+      switch (ch) {
+        case "&": return "&amp;";
+        case "<": return "&lt;";
+        case ">": return "&gt;";
+        case '"': return "&quot;";
+        default: return ch;
+      }
+    });
+  }
+
+  function downloadCsv(rows, snapshot) {
+    if (!rows.length) {
+      return;
+    }
+    const hidden = new Set(snapshot.hiddenColumns || []);
+    const visibleOrder = snapshot.order.filter(colId => !hidden.has(colId));
+    const headers = visibleOrder.map(colId => (columns[colId] ? columns[colId].label.replace(/&ntilde;/g, "ñ").replace(/<[^>]+>/g, "") : colId));
+    const lines = [headers.join(";")];
+    rows.forEach(row => {
+      const values = visibleOrder.map(colId => {
+        const col = columns[colId];
+        const raw = col && col.csv ? col.csv(row) : (col && col.get ? col.get(row) : row[colId]);
+        const text = (raw ?? "").toString().replace(/"/g, '""');
+        return '"' + text + '"';
+      });
+      lines.push(values.join(";"));
+    });
+    const blob = new Blob([lines.join("\r\n")], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = "inventario_filtrado.csv";
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    window.setTimeout(() => URL.revokeObjectURL(url), 200);
+  }
+
+})(window, document);

--- a/docs/assets/js/inventory-state.js
+++ b/docs/assets/js/inventory-state.js
@@ -1,0 +1,595 @@
+(function(window){
+  "use strict";
+
+  const FALLBACK_PREFIX = "mingomedia.inventory.view";
+  const FALLBACK_WIDTH = 150;
+  const FALLBACK_MIN_WIDTH = 80;
+
+  function normalizeUserKey(value, fallback) {
+    if (value === undefined || value === null) {
+      return fallback || "public";
+    }
+    let text = String(value).trim();
+    if (!text) {
+      return fallback || "public";
+    }
+    text = text.toLowerCase();
+    return text.replace(/[^a-z0-9_.@-]+/g, "_");
+  }
+
+  function sanitizeOrder(order, available) {
+    const allowed = Array.isArray(available) && available.length ? available : [];
+    const result = [];
+    const seen = new Set();
+    const source = Array.isArray(order) ? order : [];
+
+    source.forEach(function(item){
+      const id = item === undefined || item === null ? "" : String(item).trim();
+      if (!id) { return; }
+      if (allowed.length && !allowed.includes(id)) { return; }
+      if (seen.has(id)) { return; }
+      seen.add(id);
+      result.push(id);
+    });
+
+    const fallbackSource = allowed.length ? allowed : source;
+    fallbackSource.forEach(function(item){
+      const id = item === undefined || item === null ? "" : String(item).trim();
+      if (!id || seen.has(id)) { return; }
+      seen.add(id);
+      result.push(id);
+    });
+
+    return result;
+  }
+
+  function sanitizeWidths(widths, available, defaults, minWidth) {
+    const result = {};
+    const list = Array.isArray(available) && available.length ? available : Object.keys(widths || {});
+    const base = defaults && typeof defaults === "object" ? defaults : {};
+    const floor = typeof minWidth === "number" && minWidth > 0 ? minWidth : FALLBACK_MIN_WIDTH;
+
+    list.forEach(function(column){
+      const key = column === undefined || column === null ? "" : String(column).trim();
+      if (!key) { return; }
+      const candidate = widths && Object.prototype.hasOwnProperty.call(widths, key) ? widths[key] : undefined;
+      const defaultWidth = base && Object.prototype.hasOwnProperty.call(base, key) ? base[key] : FALLBACK_WIDTH;
+      let value = Number(candidate);
+      if (!Number.isFinite(value) || value <= 0) {
+        value = Number(defaultWidth);
+      }
+      if (!Number.isFinite(value) || value <= 0) {
+        value = FALLBACK_WIDTH;
+      }
+      result[key] = Math.max(floor, Math.round(value));
+    });
+
+    return result;
+  }
+
+  function sanitizeRowHeights(input) {
+    const result = {};
+    if (!input || typeof input !== "object") {
+      return result;
+    }
+    Object.keys(input).forEach(function(key){
+      const value = Number(input[key]);
+      if (Number.isFinite(value) && value > 0) {
+        result[String(key)] = value;
+      }
+    });
+    return result;
+  }
+
+  function createMingoInventoryStore(options) {
+    const opts = options && typeof options === "object" ? options : {};
+    const allColumns = Array.isArray(opts.allColumns) ? opts.allColumns.filter(Boolean).map(function(col){return String(col);}) : [];
+    const defaultOrder = sanitizeOrder(Array.isArray(opts.defaultOrder) ? opts.defaultOrder : allColumns, allColumns);
+    const minColumnWidth = typeof opts.minColumnWidth === "number" && opts.minColumnWidth > 0 ? opts.minColumnWidth : FALLBACK_MIN_WIDTH;
+    const defaultWidths = sanitizeWidths(opts.defaultWidths || {}, allColumns.length ? allColumns : defaultOrder, opts.defaultWidths || {}, minColumnWidth);
+    const storagePrefix = typeof opts.storagePrefix === "string" && opts.storagePrefix.trim() ? opts.storagePrefix.trim() : FALLBACK_PREFIX;
+    const defaultUserKey = normalizeUserKey(opts.defaultUserKey || opts.defaultUser || "public", "public");
+
+    const availableColumns = (allColumns.length ? allColumns.slice() : defaultOrder.slice()).map(function(col){return String(col);});
+
+    const state = {
+      order: defaultOrder.slice(),
+      widths: Object.assign({}, defaultWidths),
+      hiddenColumns: new Set(Array.isArray(opts.hiddenColumns) ? opts.hiddenColumns.map(function(col){return String(col);}) : []),
+      hiddenRows: new Set(Array.isArray(opts.hiddenRows) ? opts.hiddenRows.map(function(id){return String(id);}) : []),
+      rowHeights: sanitizeRowHeights(opts.rowHeights),
+      selectedRows: new Set(Array.isArray(opts.selectedRows) ? opts.selectedRows.map(function(id){return String(id);}) : []),
+      selectionOrder: Array.isArray(opts.selectionOrder) ? opts.selectionOrder.map(function(id){return String(id);}) : [],
+      filters: Object.assign({}, opts.initialFilters || {}),
+      search: opts.initialSearch ? String(opts.initialSearch) : "",
+      pageSize: typeof opts.initialPageSize === "number" && opts.initialPageSize >= 0 ? Math.floor(opts.initialPageSize) : 50,
+      page: typeof opts.initialPage === "number" && opts.initialPage > 0 ? Math.floor(opts.initialPage) : 1,
+      activeUnit: opts.initialActiveUnit ? String(opts.initialActiveUnit) : "",
+      defaultOrder: defaultOrder.slice(),
+      defaultWidths: Object.assign({}, defaultWidths)
+    };
+
+    if (!state.selectionOrder.length && state.selectedRows.size) {
+      state.selectionOrder = Array.from(state.selectedRows);
+    }
+
+    let userKey = normalizeUserKey(opts.initialUserKey || opts.initialUser || defaultUserKey, defaultUserKey);
+    const listeners = new Map();
+
+    function getStorageKey() {
+      if (!userKey) {
+        return null;
+      }
+      return storagePrefix + ":" + userKey;
+    }
+
+    function snapshot() {
+      return {
+        order: state.order.slice(),
+        widths: Object.assign({}, state.widths),
+        hiddenColumns: Array.from(state.hiddenColumns),
+        filters: Object.assign({}, state.filters),
+        search: state.search,
+        pageSize: state.pageSize,
+        page: state.page,
+        activeUnit: state.activeUnit,
+        hiddenRows: Array.from(state.hiddenRows),
+        rowHeights: Object.assign({}, state.rowHeights),
+        selectedRows: Array.from(state.selectedRows),
+        selectionOrder: state.selectionOrder.slice(),
+        userKey: userKey
+      };
+    }
+
+    function emit(event, detail) {
+      const handlers = listeners.get(event);
+      if (!handlers || !handlers.size) {
+        return;
+      }
+      handlers.forEach(function(handler){
+        try {
+          handler(detail, snapshot());
+        } catch (error) {
+          console.error("Inventory store listener error", error);
+        }
+      });
+    }
+
+    function emitChange() {
+      emit("change", snapshot());
+    }
+
+    function persistView() {
+      const key = getStorageKey();
+      if (!key) {
+        return false;
+      }
+      const payload = {
+        order: state.order.slice(),
+        widths: Object.assign({}, state.widths),
+        hiddenColumns: Array.from(state.hiddenColumns),
+        hiddenRows: Array.from(state.hiddenRows),
+        rowHeights: Object.assign({}, state.rowHeights),
+        selectedRows: Array.from(state.selectedRows),
+        selectionOrder: state.selectionOrder.slice()
+      };
+      try {
+        window.localStorage.setItem(key, JSON.stringify(payload));
+        return true;
+      } catch (error) {
+        console.warn("No se pudo guardar la vista", error);
+        return false;
+      }
+    }
+
+    function applyViewSnapshot(saved) {
+      if (!saved || typeof saved !== "object") {
+        return;
+      }
+      if (Array.isArray(saved.order) && saved.order.length) {
+        state.order = sanitizeOrder(saved.order, availableColumns);
+      } else {
+        state.order = state.defaultOrder.slice();
+      }
+      if (saved.widths && typeof saved.widths === "object") {
+        const merged = Object.assign({}, state.defaultWidths, saved.widths);
+        state.widths = sanitizeWidths(merged, availableColumns, state.defaultWidths, minColumnWidth);
+      } else {
+        state.widths = sanitizeWidths(state.defaultWidths, availableColumns, state.defaultWidths, minColumnWidth);
+      }
+      state.hiddenColumns = new Set(Array.isArray(saved.hiddenColumns) ? saved.hiddenColumns.filter(function(col){return availableColumns.includes(col);}).map(function(col){return String(col);}) : []);
+      state.hiddenRows = new Set(Array.isArray(saved.hiddenRows) ? saved.hiddenRows.map(function(id){return String(id);}) : []);
+      state.rowHeights = sanitizeRowHeights(saved.rowHeights);
+      const selected = Array.isArray(saved.selectedRows) ? saved.selectedRows.map(function(id){return String(id);}) : [];
+      state.selectedRows = new Set(selected);
+      state.selectionOrder = Array.isArray(saved.selectionOrder) && saved.selectionOrder.length ? saved.selectionOrder.map(function(id){return String(id);}) : selected.slice();
+    }
+
+    function loadFromStorageInternal(triggerEvents) {
+      const key = getStorageKey();
+      if (!key) {
+        return false;
+      }
+      let raw = null;
+      try {
+        raw = window.localStorage.getItem(key);
+      } catch (error) {
+        console.warn("No se pudo leer la vista", error);
+        return false;
+      }
+      if (!raw) {
+        return false;
+      }
+      try {
+        const saved = JSON.parse(raw);
+        applyViewSnapshot(saved);
+        if (triggerEvents) {
+          emit("view:hydrate", snapshot());
+          emitChange();
+        }
+        return true;
+      } catch (error) {
+        console.warn("Vista almacenada corrupta", error);
+        return false;
+      }
+    }
+
+    function ensureSelectionOrder() {
+      if (!state.selectionOrder.length && state.selectedRows.size) {
+        state.selectionOrder = Array.from(state.selectedRows);
+      } else if (state.selectionOrder.length) {
+        const valid = new Set(state.selectedRows);
+        state.selectionOrder = state.selectionOrder.filter(function(id){return valid.has(id);});
+        if (state.selectionOrder.length < state.selectedRows.size) {
+          state.selectedRows.forEach(function(id){
+            if (!state.selectionOrder.includes(id)) {
+              state.selectionOrder.push(id);
+            }
+          });
+        }
+      }
+    }
+
+    const api = {
+      getState: snapshot,
+      on: function(event, handler){
+        if (!event || typeof handler !== "function") {
+          return function(){};
+        }
+        const key = String(event);
+        const handlers = listeners.get(key) || new Set();
+        handlers.add(handler);
+        listeners.set(key, handlers);
+        return function(){
+          handlers.delete(handler);
+          if (!handlers.size) {
+            listeners.delete(key);
+          }
+        };
+      },
+      off: function(event, handler){
+        if (!event) { return; }
+        const handlers = listeners.get(String(event));
+        if (!handlers) { return; }
+        if (typeof handler === "function") {
+          handlers.delete(handler);
+        }
+        if (!handler || !handlers.size) {
+          listeners.delete(String(event));
+        }
+      },
+      setUser: function(next){
+        const normalized = normalizeUserKey(next, defaultUserKey);
+        const changed = normalized !== userKey;
+        userKey = normalized;
+        const hydrated = loadFromStorageInternal(true);
+        emit("user:change", { userKey: userKey });
+        if (!hydrated && changed) {
+          emitChange();
+        }
+      },
+      getUser: function(){
+        return userKey;
+      },
+      resetColumns: function(){
+        state.order = state.defaultOrder.slice();
+        state.widths = sanitizeWidths(state.defaultWidths, availableColumns, state.defaultWidths, minColumnWidth);
+        state.hiddenColumns = new Set();
+        persistView();
+        emit("columns:order", { order: state.order.slice() });
+        emit("columns:hidden", { hidden: [] });
+        emit("columns:width", { widths: Object.assign({}, state.widths) });
+        emitChange();
+      },
+      setColumnOrder: function(order){
+        const next = sanitizeOrder(order, availableColumns);
+        if (next.join("|") === state.order.join("|")) {
+          return;
+        }
+        state.order = next;
+        persistView();
+        emit("columns:order", { order: state.order.slice() });
+        emitChange();
+      },
+      setColumnWidth: function(columnId, width){
+        const key = columnId === undefined || columnId === null ? "" : String(columnId).trim();
+        if (!key) { return; }
+        const value = Math.max(minColumnWidth, Math.round(Number(width)) || 0);
+        if (state.widths[key] === value) {
+          return;
+        }
+        state.widths[key] = value;
+        persistView();
+        emit("columns:width", { columnId: key, width: value, widths: Object.assign({}, state.widths) });
+        emitChange();
+      },
+      setHiddenColumns: function(columns){
+        const next = new Set();
+        (Array.isArray(columns) ? columns : []).forEach(function(col){
+          const key = col === undefined || col === null ? "" : String(col).trim();
+          if (key && availableColumns.includes(key)) {
+            next.add(key);
+          }
+        });
+        const current = Array.from(state.hiddenColumns);
+        const nextList = Array.from(next);
+        if (current.length === nextList.length && current.every(function(col, idx){return col === nextList[idx];})) {
+          return;
+        }
+        state.hiddenColumns = next;
+        persistView();
+        emit("columns:hidden", { hidden: nextList.slice() });
+        emitChange();
+      },
+      hideColumn: function(columnId){
+        const key = columnId === undefined || columnId === null ? "" : String(columnId).trim();
+        if (!key || !availableColumns.includes(key) || state.hiddenColumns.has(key)) {
+          return;
+        }
+        state.hiddenColumns.add(key);
+        persistView();
+        emit("columns:hidden", { hidden: Array.from(state.hiddenColumns) });
+        emitChange();
+      },
+      showColumn: function(columnId){
+        const key = columnId === undefined || columnId === null ? "" : String(columnId).trim();
+        if (!key || !state.hiddenColumns.has(key)) {
+          return;
+        }
+        state.hiddenColumns.delete(key);
+        persistView();
+        emit("columns:hidden", { hidden: Array.from(state.hiddenColumns) });
+        emitChange();
+      },
+      setHiddenRows: function(rowIds){
+        const next = new Set();
+        (Array.isArray(rowIds) ? rowIds : []).forEach(function(id){
+          const key = id === undefined || id === null ? "" : String(id);
+          if (key) {
+            next.add(key);
+          }
+        });
+        const current = Array.from(state.hiddenRows);
+        const nextList = Array.from(next);
+        if (current.length === nextList.length && current.every(function(id, idx){return id === nextList[idx];})) {
+          return;
+        }
+        state.hiddenRows = next;
+        persistView();
+        emit("rows:hidden", { hidden: nextList.slice() });
+        emitChange();
+      },
+      toggleRowHidden: function(rowId){
+        const key = rowId === undefined || rowId === null ? "" : String(rowId);
+        if (!key) { return; }
+        if (state.hiddenRows.has(key)) {
+          state.hiddenRows.delete(key);
+        } else {
+          state.hiddenRows.add(key);
+        }
+        persistView();
+        emit("rows:hidden", { hidden: Array.from(state.hiddenRows) });
+        emitChange();
+      },
+      setRowHeight: function(rowId, height){
+        const key = rowId === undefined || rowId === null ? "" : String(rowId);
+        if (!key) { return; }
+        const value = Number(height);
+        if (!Number.isFinite(value) || value <= 0) {
+          if (Object.prototype.hasOwnProperty.call(state.rowHeights, key)) {
+            delete state.rowHeights[key];
+            persistView();
+            emit("rows:height", { rowId: key, height: null, heights: Object.assign({}, state.rowHeights) });
+            emitChange();
+          }
+          return;
+        }
+        if (state.rowHeights[key] === value) {
+          return;
+        }
+        state.rowHeights[key] = value;
+        persistView();
+        emit("rows:height", { rowId: key, height: value, heights: Object.assign({}, state.rowHeights) });
+        emitChange();
+      },
+      setSearch: function(value){
+        const next = value ? String(value).trim() : "";
+        if (state.search === next) { return; }
+        state.search = next;
+        state.page = 1;
+        emit("filters:change", { filters: Object.assign({}, state.filters), search: state.search, page: state.page, activeUnit: state.activeUnit });
+        emitChange();
+      },
+      setFilter: function(columnId, value){
+        const key = columnId === undefined || columnId === null ? "" : String(columnId).trim();
+        if (!key) { return; }
+        const next = value ? String(value).trim() : "";
+        const current = Object.prototype.hasOwnProperty.call(state.filters, key) ? state.filters[key] : "";
+        if (current === next) { return; }
+        if (next) {
+          state.filters[key] = next;
+        } else {
+          delete state.filters[key];
+        }
+        state.page = 1;
+        emit("filters:change", { filters: Object.assign({}, state.filters), search: state.search, page: state.page, activeUnit: state.activeUnit });
+        emitChange();
+      },
+      setFilters: function(filters){
+        const next = {};
+        if (filters && typeof filters === "object") {
+          Object.keys(filters).forEach(function(key){
+            const value = filters[key];
+            if (value !== undefined && value !== null && String(value).trim()) {
+              next[String(key)] = String(value).trim();
+            }
+          });
+        }
+        const currentKeys = Object.keys(state.filters);
+        const nextKeys = Object.keys(next);
+        if (currentKeys.length === nextKeys.length && currentKeys.every(function(key){ return state.filters[key] === next[key]; })) {
+          return;
+        }
+        state.filters = next;
+        state.page = 1;
+        emit("filters:change", { filters: Object.assign({}, state.filters), search: state.search, page: state.page, activeUnit: state.activeUnit });
+        emitChange();
+      },
+      clearFilters: function(){
+        if (!Object.keys(state.filters).length && !state.search && !state.activeUnit) {
+          return;
+        }
+        state.filters = {};
+        state.search = "";
+        state.activeUnit = "";
+        state.page = 1;
+        emit("filters:change", { filters: {}, search: "", page: state.page, activeUnit: "" });
+        emitChange();
+      },
+      setPageSize: function(size){
+        const value = typeof size === "number" ? Math.max(0, Math.floor(size)) : 0;
+        if (state.pageSize === value) { return; }
+        state.pageSize = value;
+        state.page = 1;
+        emit("page:change", { pageSize: state.pageSize, page: state.page });
+        emitChange();
+      },
+      setPage: function(page){
+        const value = typeof page === "number" ? Math.max(1, Math.floor(page)) : 1;
+        if (state.page === value) { return; }
+        state.page = value;
+        emit("page:change", { pageSize: state.pageSize, page: state.page });
+        emitChange();
+      },
+      setActiveUnit: function(unit){
+        const value = unit ? String(unit).trim() : "";
+        if (state.activeUnit === value) { return; }
+        state.activeUnit = value;
+        state.page = 1;
+        emit("filters:change", { filters: Object.assign({}, state.filters), search: state.search, page: state.page, activeUnit: state.activeUnit });
+        emitChange();
+      },
+      updateSelection: function(options){
+        const optsSel = options && typeof options === "object" ? options : {};
+        const add = Array.isArray(optsSel.add) ? optsSel.add.map(function(id){return String(id);}) : [];
+        const remove = Array.isArray(optsSel.remove) ? new Set(optsSel.remove.map(function(id){return String(id);})): new Set();
+        let changed = false;
+        add.forEach(function(id){
+          if (!id || remove.has(id)) { return; }
+          if (!state.selectedRows.has(id)) {
+            state.selectedRows.add(id);
+            state.selectionOrder.push(id);
+            changed = true;
+          }
+        });
+        if (remove.size) {
+          state.selectionOrder = state.selectionOrder.filter(function(id){
+            if (!remove.has(id)) { return true; }
+            if (state.selectedRows.has(id)) {
+              state.selectedRows.delete(id);
+              changed = true;
+            }
+            return false;
+          });
+          remove.forEach(function(id){
+            if (state.selectedRows.delete(id)) {
+              changed = true;
+            }
+          });
+        }
+        ensureSelectionOrder();
+        if (changed) {
+          persistView();
+          emit("selection:change", { selected: Array.from(state.selectedRows), order: state.selectionOrder.slice() });
+          emitChange();
+        }
+      },
+      toggleRowSelection: function(rowId, forced){
+        const key = rowId === undefined || rowId === null ? "" : String(rowId);
+        if (!key) { return; }
+        const has = state.selectedRows.has(key);
+        const shouldSelect = typeof forced === "boolean" ? forced : !has;
+        if (shouldSelect && !has) {
+          state.selectedRows.add(key);
+          if (!state.selectionOrder.includes(key)) {
+            state.selectionOrder.push(key);
+          }
+        } else if (!shouldSelect && has) {
+          state.selectedRows.delete(key);
+          state.selectionOrder = state.selectionOrder.filter(function(id){return id !== key;});
+        } else {
+          return;
+        }
+        ensureSelectionOrder();
+        persistView();
+        emit("selection:change", { selected: Array.from(state.selectedRows), order: state.selectionOrder.slice(), rowId: key });
+        emitChange();
+      },
+      setSelectedRows: function(rowIds){
+        const next = new Set();
+        (Array.isArray(rowIds) ? rowIds : []).forEach(function(id){
+          const key = id === undefined || id === null ? "" : String(id);
+          if (key) {
+            next.add(key);
+          }
+        });
+        const current = Array.from(state.selectedRows);
+        const nextList = Array.from(next);
+        if (current.length === nextList.length && current.every(function(id, idx){return id === nextList[idx];})) {
+          return;
+        }
+        state.selectedRows = next;
+        state.selectionOrder = nextList.slice();
+        ensureSelectionOrder();
+        persistView();
+        emit("selection:change", { selected: Array.from(state.selectedRows), order: state.selectionOrder.slice() });
+        emitChange();
+      },
+      clearSelection: function(){
+        if (!state.selectedRows.size && !state.selectionOrder.length) {
+          return;
+        }
+        state.selectedRows.clear();
+        state.selectionOrder = [];
+        persistView();
+        emit("selection:change", { selected: [], order: [] });
+        emitChange();
+      },
+      getSelection: function(){
+        return { selected: Array.from(state.selectedRows), order: state.selectionOrder.slice() };
+      },
+      persist: function(){
+        persistView();
+      },
+      loadFromStorage: function(){
+        loadFromStorageInternal(true);
+      }
+    };
+
+    loadFromStorageInternal(false);
+
+    return api;
+  }
+
+  window.createMingoInventoryStore = createMingoInventoryStore;
+})(window);

--- a/docs/assets/js/mingomedia-config.js
+++ b/docs/assets/js/mingomedia-config.js
@@ -1,0 +1,35 @@
+(function(window){
+  "use strict";
+
+  if (!window.MingoMediaConfig || typeof window.MingoMediaConfig !== "object") {
+    window.MingoMediaConfig = {};
+  }
+
+  const cfg = window.MingoMediaConfig;
+
+  if (!cfg.access || typeof cfg.access !== "object") {
+    cfg.access = {};
+  }
+
+  if (!cfg.view || typeof cfg.view !== "object") {
+    cfg.view = {};
+  }
+
+  cfg.access = Object.assign({
+    enabled: false,
+    requireEmail: true,
+    requirePin: false,
+    allowedEmails: [],
+    allowedDomains: [],
+    users: [],
+    message: "Introduce tu correo para continuar.",
+    rememberSession: true,
+    version: "v1"
+  }, cfg.access);
+
+  cfg.view = Object.assign({
+    storagePrefix: "mingomedia.inventory.view",
+    defaultUser: "public"
+  }, cfg.view);
+
+})(window);

--- a/docs/index.html
+++ b/docs/index.html
@@ -34,9 +34,17 @@ h1{margin:0 0 12px;font-size:28px;font-weight:700;color:#0b1733}
 table{width:100%;border-collapse:separate;border-spacing:0;min-width:840px}
 thead tr:first-child th{position:sticky;top:0;background:#ecf1ff;color:#0f172a;font-size:13px;font-weight:600;z-index:2}
 thead tr.filters th{position:sticky;top:46px;background:rgba(236,241,255,0.96);backdrop-filter:blur(3px);z-index:1}
+.selector-header,.row-selector-cell{width:48px;min-width:48px;text-align:center;padding:0 8px}
+.selector-header{position:sticky;left:0;background:#ecf1ff;border-right:1px solid #dbe4ff;z-index:3}
+.row-selector-cell{position:sticky;left:0;background:#fff;border-right:1px solid #e2e8f0}
+tbody tr:nth-child(even) .row-selector-cell{background:#f8faff}
+tbody tr:hover .row-selector-cell{background:#e8f1ff}
+.row-selector-cell input[type="checkbox"],.selector-header input[type="checkbox"]{width:16px;height:16px;cursor:pointer}
 th,td{padding:10px 12px;border-bottom:1px solid #e2e8f0;text-align:left;font-size:13px;vertical-align:top}
 tbody tr:nth-child(even){background:#f8faff}
 tbody tr:hover{background:#e8f1ff}
+.row-selected{box-shadow:inset 0 0 0 2px #2563eb;background:#e0ecff}
+.row-selected .row-selector-cell{background:#d6e4ff}
 .muted{color:#475569;font-size:12px}
 .wrap{text-overflow:ellipsis;overflow:hidden;white-space:nowrap}
 .col-size{text-align:right;font-variant-numeric:tabular-nums}
@@ -59,6 +67,23 @@ thead input{width:100%;padding:7px 8px;border:1px solid #cbd5f5;border-radius:8p
 .pagination button:hover:not(:disabled){border-color:#2563eb;color:#2563eb}
 .pagination button:disabled{opacity:.45;cursor:not-allowed}
 .pagination .info{font-size:13px;color:#475569}
+.selection-indicator{font-size:13px;color:#1f2937;display:flex;align-items:center;gap:4px}
+.selection-indicator[hidden]{display:none}
+.selection-indicator strong{font-weight:600;color:#2563eb}
+.access-gate{position:fixed;inset:0;background:rgba(15,23,42,.75);display:flex;align-items:center;justify-content:center;padding:24px;backdrop-filter:blur(4px);z-index:9999}
+.access-gate[hidden]{display:none}
+.access-card{max-width:360px;width:100%;background:#fff;border-radius:18px;padding:24px;box-shadow:0 40px 90px -45px rgba(15,23,42,.6);display:flex;flex-direction:column;gap:18px}
+.access-card h2{margin:0;font-size:20px;font-weight:700;color:#0b1733}
+.access-card p{margin:0;font-size:13px;color:#475569}
+.access-form{display:flex;flex-direction:column;gap:12px}
+.access-form label{display:flex;flex-direction:column;gap:6px;font-size:13px;color:#1f2937}
+.access-form input{padding:9px 12px;border:1px solid #cbd5f5;border-radius:10px;background:#f8fafc;color:#0f172a;font-size:14px}
+.access-form input:focus{outline:none;border-color:#2563eb;box-shadow:0 0 0 3px rgba(37,99,235,.18)}
+.access-error{color:#b91c1c;background:#fee2e2;border:1px solid #fecaca;padding:10px 12px;border-radius:10px;font-size:13px}
+.access-error[hidden]{display:none}
+.access-form button{padding:10px 14px;border:none;border-radius:10px;background:#2563eb;color:#fff;font-weight:600;font-size:14px;cursor:pointer;transition:background .15s ease,transform .15s ease}
+.access-form button:hover{background:#1d4ed8;transform:translateY(-1px)}
+.access-form button:disabled{background:#94a3b8;cursor:not-allowed;transform:none}
 </style><link rel="stylesheet" href="./assets/css/picker.css"/></head><body>
 <header class="site-header">
   <div class="brand">MingoMedia</div>
@@ -96,6 +121,7 @@ thead input{width:100%;padding:7px 8px;border:1px solid #cbd5f5;border-radius:8p
 <div id="err"></div>
 <div class="toolbar">
   <div class="summary"><span id="count">0</span> archivos <span class="sep">&middot;</span> <span id="size">0</span> visibles</div>
+  <div class="selection-indicator" id="selectionIndicator" hidden><strong id="selectionCount">0</strong> seleccionados</div>
   <div class="search"><input id="q" type="search" placeholder="Buscar por ruta, nombre o hash"/></div>
   <select id="pageSize">
     <option value="25">25 por página</option>
@@ -142,439 +168,24 @@ thead input{width:100%;padding:7px 8px;border:1px solid #cbd5f5;border-radius:8p
 <script id="INV_B64" type="application/octet-stream" data-src="data/inventory.json">
 
 </script>
-<script>
-(function(){
-  const showErr=function(msg){const box=document.getElementById("err");box.textContent="[!] "+msg;box.style.display="block";console.error(msg);};
-  const baseNode=document.getElementById("INV_B64");
-  let DATA=[];
-
-  loadData().then(function(raw){
-    DATA=normalizeData(raw);
-    buildHeaders();
-    render();
-  }).catch(function(err){
-    const message=err && err.message ? err.message : String(err);
-    showErr(message);
-  });
-
-  function loadData(){
-    if(baseNode){
-      const raw=(baseNode.textContent||"").trim();
-      if(raw){
-        try{
-          return Promise.resolve(decodeBase64(raw));
-        }catch(err){
-          return Promise.reject(err);
-        }
-      }
-      const src=baseNode.getAttribute("data-src");
-      if(src){return fetchJson(src);}
-    }
-    return fetchJson("data/inventory.json");
-  }
-
-  function decodeBase64(raw){
-    const bin=atob(raw);
-    const bytes=new Uint8Array(bin.length);
-    for(let i=0;i<bin.length;i++){bytes[i]=bin.charCodeAt(i);}
-    const txt=new TextDecoder("utf-8",{fatal:false}).decode(bytes);
-    const parsed=JSON.parse(txt);
-    return Array.isArray(parsed)?parsed:(parsed.data||[]);
-  }
-
-  function fetchJson(url){
-    return fetch(url,{cache:"no-store"}).then(function(res){
-      if(!res.ok){throw new Error("No se pudo cargar "+url+" ("+res.status+")");}
-      return res.json();
-    });
-  }
-
-  function normalizeData(source){
-    return (source||[]).map(function(row){
-      return {
-        sha:row.sha||"",
-        tipo:row.tipo||row.type||"",
-        nombre:row.nombre||row.name||"",
-        ruta:row.ruta||row.dir||row.path||"",
-        unidad:(row.unidad||row.drive||"").toString().trim(),
-        tamano:Number((row.tamano??row.size??row.length) || 0),
-        fecha:row.fecha||row.date||row.lastWriteTime||""
-      };
-    });
-  }
-
-  const elements={
-    tableShell:document.getElementById("tableShell"),
-    headerRow:document.getElementById("headerRow"),
-    filterRow:document.getElementById("filterRow"),
-    tbody:document.querySelector("#tbl tbody"),
-    q:document.getElementById("q"),
-    chips:document.getElementById("unitChips"),
-    count:document.getElementById("count"),
-    size:document.getElementById("size"),
-    pageSize:document.getElementById("pageSize"),
-    prev:document.getElementById("prevPage"),
-    next:document.getElementById("nextPage"),
-  pageInfo:document.getElementById("pageInfo"),
-  download:document.getElementById("downloadBtn"),
-  resetCols:document.getElementById("resetColumns"),
-  unitSummary:document.getElementById("unitSummary"),
-  extSummary:document.getElementById("extSummary"),
-  pathSummary:document.getElementById("pathSummary")
-};
-
-  const defaultOrder=["sha","tipo","nombre","ruta","unidad","tamano","fecha"];
-  const defaultWidths={sha:240,tipo:120,nombre:260,ruta:320,unidad:90,tamano:130,fecha:160};
-
-  const columns={
-    sha:{id:"sha",label:"SHA",type:"text",className:"muted wrap",get:r=>r.sha||"",filterPlaceholder:"Filtrar hash",csv:r=>r.sha||""},
-    tipo:{id:"tipo",label:"Tipo",type:"text",get:r=>r.tipo||"",filterPlaceholder:"Filtrar tipo"},
-    nombre:{id:"nombre",label:"Nombre",type:"text",get:r=>r.nombre||"",render:r=>cellFileLink(r),filterPlaceholder:"Filtrar nombre",csv:r=>r.nombre||""},
-    ruta:{id:"ruta",label:"Ruta/Carpeta",type:"text",get:r=>r.ruta||"",render:r=>cellFolderLink(r),filterPlaceholder:"Filtrar ruta",csv:r=>r.ruta||""},
-    unidad:{id:"unidad",label:"Unidad",type:"text",get:r=>r.unidad||"",filterPlaceholder:"Filtrar unidad"},
-    tamano:{id:"tamano",label:"Tama&ntilde;o",type:"number",className:"col-size",get:r=>Number(r.tamano||0),render:r=>escapeHtml(human(r.tamano)),filterPlaceholder:">=, <=, =",csv:r=>Number(r.tamano||0)},
-    fecha:{id:"fecha",label:"Fecha",type:"date",className:"col-date",get:r=>r.fecha||"",render:r=>escapeHtml(formatDate(r.fecha)),filterPlaceholder:"YYYY-MM-DD",csv:r=>r.fecha||""}
-  };
-
-  const state={order:defaultOrder.slice(),widths:Object.assign({},defaultWidths),filters:Object.create(null),search:"",pageSize:50,page:1,activeUnit:""};
-  let dragSource=null;
-
-  function human(bytes){
-    if(!bytes||Number.isNaN(bytes)){return "0 B";}
-    const units=["B","KB","MB","GB","TB","PB"];
-    let value=Number(bytes);
-    let idx=0;
-    while(value>=1024 && idx<units.length-1){value/=1024;idx++;}
-    return value.toFixed(idx===0?0:1)+" "+units[idx];
-  }
-  function formatDate(value){return value?(value.replace("T"," ").replace("Z","")):"";}
-  function escapeHtml(text){return (text??"").toString().replace(/[&<>"]/g,function(ch){switch(ch){case"&":return"&amp;";case"<":return"&lt;";case">":return"&gt;";case"\"":return"&quot;";default:return ch;}});}
-  function joinWinPath(dir,name){if(!dir){return name||"";}if(!name){return dir;}const sep=(dir.endsWith("\\")||dir.endsWith("/"))?"":"\\";return dir+sep+name;}
-  function toFileUrl(path){
-    if(!path){return"";}
-    let normalized=path.replace(/\\/g,"/").replace(/^\.\/+/,"");
-    const driveMatch=normalized.match(/^([A-Za-z]):\/?(.*)$/);
-    let prefix="file:///";
-    let rest=normalized;
-    if(driveMatch){
-      prefix+=driveMatch[1].toUpperCase()+":/";
-      rest=driveMatch[2];
-    }
-    const encoded=rest.split("/").filter(Boolean).map(function(part){return encodeURIComponent(part);}).join("/");
-    return prefix+encoded;
-  }
-  function cellFileLink(row){
-    const full=joinWinPath(row.ruta,row.nombre);
-    const url=toFileUrl(full);
-    const label=escapeHtml(row.nombre||"");
-    if(!url){return label;}
-    return "<a class=\"cell-link\" href=\""+url+"\" title=\"Abrir archivo\" target=\"_blank\" rel=\"noopener\">"+label+"</a>";
-  }
-  function cellFolderLink(row){
-    const url=toFileUrl(row.ruta||"");
-    const label=escapeHtml(row.ruta||"");
-    if(!url){return label;}
-    return "<a class=\"cell-link\" href=\""+url+"\" title=\"Abrir carpeta\" target=\"_blank\" rel=\"noopener\">"+label+"</a>";
-  }
-
-  function buildHeaders(){
-    elements.headerRow.innerHTML="";
-    elements.filterRow.innerHTML="";
-    state.order.forEach(function(colId){
-      const col=columns[colId];
-      const th=document.createElement("th");
-      th.dataset.col=colId;
-      th.draggable=true;
-      const width=state.widths[colId]||defaultWidths[colId]||150;
-      th.style.width=width+"px";
-      const wrapper=document.createElement("div");
-      wrapper.className="th-content";
-      const label=document.createElement("span");
-      label.className="th-label";
-      label.innerHTML=col.label;
-      wrapper.appendChild(label);
-      th.appendChild(wrapper);
-      const handle=document.createElement("span");
-      handle.className="resize-handle";
-      th.appendChild(handle);
-
-      handle.addEventListener("pointerdown",function(ev){
-        ev.preventDefault();ev.stopPropagation();
-        const startX=ev.clientX;
-        const startWidth=th.getBoundingClientRect().width;
-        function onMove(moveEvent){
-          const delta=moveEvent.clientX-startX;
-          const newWidth=Math.max(80,startWidth+delta);
-          th.style.width=newWidth+"px";
-          state.widths[colId]=newWidth;
-        }
-        function onUp(){window.removeEventListener("pointermove",onMove);window.removeEventListener("pointerup",onUp);}
-        window.addEventListener("pointermove",onMove);
-        window.addEventListener("pointerup",onUp,{once:true});
-      });
-
-      th.addEventListener("dragstart",function(ev){
-        dragSource=colId;
-        th.classList.add("drag-source");
-        elements.tableShell.classList.add("drag-active");
-        ev.dataTransfer.effectAllowed="move";
-      });
-      th.addEventListener("dragend",function(){
-        dragSource=null;
-        th.classList.remove("drag-source");
-        elements.tableShell.classList.remove("drag-active");
-        Array.from(elements.headerRow.children).forEach(function(node){node.classList.remove("drop-target");});
-      });
-      th.addEventListener("dragover",function(ev){
-        ev.preventDefault();
-        if(!dragSource || dragSource===colId){return;}
-        th.classList.add("drop-target");
-      });
-      th.addEventListener("dragleave",function(){th.classList.remove("drop-target");});
-      th.addEventListener("drop",function(ev){
-        ev.preventDefault();
-        th.classList.remove("drop-target");
-        if(!dragSource || dragSource===colId){return;}
-        const order=state.order.slice();
-        const fromIdx=order.indexOf(dragSource);
-        const toIdx=order.indexOf(colId);
-        order.splice(fromIdx,1);
-        order.splice(toIdx,0,dragSource);
-        state.order=order;
-        buildHeaders();
-        render();
-      });
-
-      elements.headerRow.appendChild(th);
-
-      const filterCell=document.createElement("th");
-      let placeholder="Filtrar";
-      if(col.type==="number"){placeholder=">=, <=, =";}
-      else if(col.type==="date"){placeholder="YYYY-MM-DD";}
-      else if(col.filterPlaceholder){placeholder=col.filterPlaceholder;}
-      filterCell.innerHTML="<input data-col=\""+colId+"\" placeholder=\""+placeholder+"\"/>";
-      const input=filterCell.querySelector("input");
-      if(input){
-        input.value=state.filters[colId]||"";
-        input.addEventListener("input",function(ev){
-          state.filters[colId]=ev.target.value.trim();
-          state.page=1;
-          render();
-        });
-      }
-      elements.filterRow.appendChild(filterCell);
-    });
-  }
-
-  function applyFilters(skipUnit){
-    const searchTerm=state.search.toLowerCase();
-    const hasSearch=searchTerm.length>0;
-    return DATA.filter(function(row){
-      if(!skipUnit && state.activeUnit && row.unidad!==state.activeUnit){return false;}
-      if(hasSearch){
-        const hay=(row.nombre+" "+row.ruta+" "+row.sha+" "+row.tipo+" "+row.unidad).toLowerCase();
-        if(!hay.includes(searchTerm)){return false;}
-      }
-      for(const key in state.filters){
-        if(!Object.prototype.hasOwnProperty.call(state.filters,key)){continue;}
-        const raw=state.filters[key];
-        if(!raw){continue;}
-        if(key==="tamano"){
-          const match=raw.match(/^\s*(>=|<=|=)\s*(\d+)\s*$/);
-          const current=Number(row.tamano||0);
-          if(match){
-            const op=match[1];
-            const val=Number(match[2]);
-            if(op===">=" && !(current>=val)){return false;}
-            if(op==="<=" && !(current<=val)){return false;}
-            if(op==="=" && current!==val){return false;}
-          }else{
-            if(human(current).toLowerCase().indexOf(raw.toLowerCase())===-1){return false;}
-          }
-        }else if(key==="fecha"){
-          if(!(row.fecha||"").toLowerCase().startsWith(raw.toLowerCase())){return false;}
-        }else{
-          const compare=(row[key]||"").toString().toLowerCase();
-          if(!compare.includes(raw.toLowerCase())){return false;}
-        }
-      }
-      return true;
-    });
-  }
-
-  function renderChips(rows){
-    elements.chips.innerHTML="";
-    const counts=new Map();
-    rows.forEach(function(row){
-      if(!row.unidad){return;}
-      counts.set(row.unidad,(counts.get(row.unidad)||0)+1);
-    });
-    const allBtn=document.createElement("button");
-    allBtn.textContent="Todas ("+rows.length+")";
-    allBtn.className="chip-all";
-    allBtn.dataset.active=state.activeUnit===""?"true":"false";
-    allBtn.addEventListener("click",function(){state.activeUnit="";state.page=1;render();});
-    elements.chips.appendChild(allBtn);
-    const entries=Array.from(counts.entries());
-    if(state.activeUnit && !counts.has(state.activeUnit)){
-      entries.push([state.activeUnit,0]);
-    }
-    entries.sort(function(a,b){
-      return a[0].localeCompare(b[0],undefined,{numeric:true,sensitivity:"base"});
-    }).forEach(function(entry){
-      const btn=document.createElement("button");
-      btn.textContent=entry[0]+" ("+entry[1]+")";
-      btn.dataset.unit=entry[0];
-      btn.dataset.active=state.activeUnit===entry[0]?"true":"false";
-      btn.addEventListener("click",function(){
-        state.activeUnit=state.activeUnit===entry[0]?"":entry[0];
-        state.page=1;
-        render();
-      });
-      elements.chips.appendChild(btn);
-    });
-  }
-
-  function renderTableBody(rows){
-    elements.tbody.innerHTML="";
-    const fragment=document.createDocumentFragment();
-    rows.forEach(function(row){
-      const tr=document.createElement("tr");
-      state.order.forEach(function(colId){
-        const col=columns[colId];
-        const td=document.createElement("td");
-        if(col.className){td.className=col.className;}
-        let html="";
-        if(col.render){html=col.render(row);}else{html=escapeHtml((col.get?col.get(row):row[colId])||"");}
-        td.innerHTML=html;
-        tr.appendChild(td);
-      });
-      fragment.appendChild(tr);
-    });
-    elements.tbody.appendChild(fragment);
-  }
-
-  function renderInsights(rows){
-    const empty="<li>Sin datos</li>";
-    elements.unitSummary.innerHTML=empty;
-    elements.extSummary.innerHTML=empty;
-    elements.pathSummary.innerHTML=empty;
-    if(!rows.length){return;}
-
-    const byUnit=new Map();
-    const byExt=new Map();
-    const byPath=new Map();
-
-    rows.forEach(function(row){
-      const unit=(row.unidad||"(sin unidad)").toString();
-      const unitStats=byUnit.get(unit)||{count:0,size:0};
-      unitStats.count+=1;
-      unitStats.size+=Number(row.tamano||0);
-      byUnit.set(unit,unitStats);
-
-      const name=row.nombre||"";
-      const ext=name.includes(".")?name.split(".").pop().toLowerCase():"(sin extensión)";
-      const extStats=byExt.get(ext)||{count:0};
-      extStats.count+=1;
-      byExt.set(ext,extStats);
-
-      const path=(row.ruta||"(sin ruta)").toString();
-      const pathStats=byPath.get(path)||{count:0};
-      pathStats.count+=1;
-      byPath.set(path,pathStats);
-    });
-
-    const unitItems=Array.from(byUnit.entries()).sort(function(a,b){
-      return b[1].count-a[1].count || b[1].size-a[1].size;
-    }).slice(0,6).map(function(entry){
-      const key=escapeHtml(entry[0]);
-      const stats=entry[1];
-      return "<li>"+key+": "+stats.count.toLocaleString("es-ES")+" archivos ("+escapeHtml(human(stats.size))+")</li>";
-    }).join("");
-
-    const extItems=Array.from(byExt.entries()).sort(function(a,b){
-      return b[1].count-a[1].count;
-    }).slice(0,6).map(function(entry){
-      const key=escapeHtml(entry[0]);
-      return "<li>"+key+": "+entry[1].count.toLocaleString("es-ES")+" archivos</li>";
-    }).join("");
-
-    const pathItems=Array.from(byPath.entries()).sort(function(a,b){
-      return b[1].count-a[1].count;
-    }).slice(0,6).map(function(entry){
-      const key=escapeHtml(entry[0]);
-      return "<li>"+key+": "+entry[1].count.toLocaleString("es-ES")+" archivos</li>";
-    }).join("");
-
-    elements.unitSummary.innerHTML=unitItems||empty;
-    elements.extSummary.innerHTML=extItems||empty;
-    elements.pathSummary.innerHTML=pathItems||empty;
-  }
-
-  function computeBytes(rows){return rows.reduce((sum,row)=>sum+Number(row.tamano||0),0);}
-  function getCurrentSlice(rows){
-    const perPage=state.pageSize;
-    if(perPage===0){return rows.slice();}
-    const totalPages=Math.max(1,Math.ceil(rows.length/perPage));
-    if(state.page>totalPages){state.page=totalPages;}
-    const start=(state.page-1)*perPage;
-    return rows.slice(start,start+perPage);
-  }
-  function renderSummary(totalRows,totalBytes){
-    elements.count.textContent=totalRows.toLocaleString("es-ES");
-    elements.size.textContent=human(totalBytes);
-    const perPage=state.pageSize;
-    const totalPages=perPage===0?1:Math.max(1,Math.ceil(totalRows/perPage));
-    if(state.page>totalPages){state.page=totalPages;}
-    const safePage=state.page;
-    const start=perPage===0?1:((safePage-1)*perPage)+1;
-    const end=perPage===0?totalRows:Math.min(totalRows,safePage*perPage);
-    elements.pageInfo.textContent=totalRows===0?"Sin resultados":`Mostrando ${start.toLocaleString("es-ES")} - ${end.toLocaleString("es-ES")} de ${totalRows.toLocaleString("es-ES")}`;
-    elements.prev.disabled=safePage<=1;
-    elements.next.disabled=safePage>=totalPages;
-  }
-  function downloadCsv(rows){
-    if(!rows.length){return;}
-    const headers=state.order.map(colId=>columns[colId].label.replace(/&ntilde;/g,"ñ").replace(/<[^>]+>/g,""));
-    const lines=[headers.join(";")];
-    rows.forEach(function(row){
-      const values=state.order.map(function(colId){
-        const col=columns[colId];
-        const raw=col.csv?col.csv(row):(col.get?col.get(row):row[colId]);
-        const text=(raw??"").toString().replace(/"/g,'""');
-        return "\""+text+"\"";
-      });
-      lines.push(values.join(";"));
-    });
-    const blob=new Blob([lines.join("\r\n")],{type:"text/csv;charset=utf-8;"});
-    const url=URL.createObjectURL(blob);
-    const link=document.createElement("a");
-    link.href=url;
-    link.download="inventario_filtrado.csv";
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    setTimeout(()=>URL.revokeObjectURL(url),200);
-  }
-
-  elements.q.addEventListener("input",function(ev){state.search=ev.target.value.trim();state.page=1;render();});
-  elements.pageSize.addEventListener("change",function(ev){state.pageSize=Number(ev.target.value);state.page=1;render();});
-  elements.prev.addEventListener("click",function(){if(state.page>1){state.page--;render();}});
-  elements.next.addEventListener("click",function(){state.page++;render();});
-  elements.download.addEventListener("click",function(){downloadCsv(applyFilters(false));});
-  elements.resetCols.addEventListener("click",function(){state.order=defaultOrder.slice();state.widths=Object.assign({},defaultWidths);buildHeaders();state.page=1;render();});
-
-  function render(){
-    const filteredWithoutUnit=applyFilters(true);
-    const filtered=applyFilters(false);
-    const bytes=computeBytes(filtered);
-    renderChips(filteredWithoutUnit);
-    renderInsights(filtered);
-    const pageRows=getCurrentSlice(filtered);
-    renderTableBody(pageRows);
-    renderSummary(filtered.length,bytes);
-    elements.download.disabled=filtered.length===0;
-  }
-
-})();
-</script></main><script defer src="./assets/js/picker.js"></script></body></html>
+</main>
+<div id="accessGate" class="access-gate" hidden>
+  <div class="access-card" role="dialog" aria-modal="true" aria-labelledby="accessTitle">
+    <h2 id="accessTitle">Acceso privado</h2>
+    <p id="accessMessage">Introduce tu correo para continuar.</p>
+    <form id="accessForm" class="access-form" novalidate>
+      <label for="accessEmail">Correo electrónico
+        <input id="accessEmail" name="email" type="email" autocomplete="email" required />
+      </label>
+      <label for="accessPin" id="accessPinLabel">PIN (opcional)
+        <input id="accessPin" name="pin" type="password" inputmode="numeric" autocomplete="one-time-code" />
+      </label>
+      <p class="access-error" id="accessError" hidden></p>
+      <button type="submit" id="accessSubmit">Entrar</button>
+    </form>
+  </div>
+</div>
+<script src="./assets/js/mingomedia-config.js"></script>
+<script src="./assets/js/inventory-state.js"></script>
+<script src="./assets/js/inventory-app.js"></script>
+<script defer src="./assets/js/picker.js"></script></body></html>


### PR DESCRIPTION
## Summary
- add a reusable inventory store with per-user persistence for column layouts, hidden rows and selections
- replace the inline table logic with inventory-app.js, including selection checkboxes and a configurable access gate overlay
- document the new mingomedia-config.js flow and load the new modules from legacy pages

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68ea905ba0b0832aa071757f4443496f