### PR TITLE
Handle missing drive roots in fileserver

### DIFF
--- a/tools/inventory-fileserver.ps1
+++ b/tools/inventory-fileserver.ps1
@@ -76,7 +76,10 @@ if ($DriveMap -and $DriveMap.Keys.Count -gt 0) {
   }
 } else {
   Get-PSDrive -PSProvider FileSystem | ForEach-Object {
-    $driveRoots[$_.Name.ToUpperInvariant()] = Normalize-Root $_.Root
+    $rootPath = Normalize-Root $_.Root
+    if ($rootPath) {
+      $driveRoots[$_.Name.ToUpperInvariant()] = $rootPath
+    }
   }
 }
 

--- a/tools/inventory-fileserver.ps1
+++ b/tools/inventory-fileserver.ps1
@@ -47,6 +47,10 @@ if (-not $Prefix -or $Prefix.Count -eq 0) {
 function Normalize-Root {
   param([string]$Path)
   if ([string]::IsNullOrWhiteSpace($Path)) { return $null }
+  if (-not (Test-Path -LiteralPath $Path)) {
+    Write-Info ("Ruta ignorada (no existe): {0}" -f $Path)
+    return $null
+  }
   $full = (Resolve-Path -LiteralPath $Path).Path
   if (-not $full.EndsWith([IO.Path]::DirectorySeparatorChar)) {
     $full += [IO.Path]::DirectorySeparatorChar


### PR DESCRIPTION
## Summary
- skip drive mappings that point to missing paths when starting the inventory fileserver
- emit an informational message so operators know the mapping was ignored instead of crashing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ebb4834db8832a858d8663e1eefce3