### PR TITLE
Fix CancelKeyPress handler for file server

### DIFF
--- a/tools/inventory-fileserver.ps1
+++ b/tools/inventory-fileserver.ps1
@@ -156,12 +156,14 @@ Write-Info ("Servidor iniciado en: {0}" -f ($Prefix -join ', '))
 Write-Info "Pulsa Ctrl+C para detener."
 
 $cancelled = $false
-$handler = {
+$handler = [System.ConsoleCancelEventHandler]{
+  param($sender, $eventArgs)
   $global:cancelled = $true
+  $eventArgs.Cancel = $true
   Write-Info "Deteniendo servidor..."
   $listener.Stop()
 }
-[Console]::CancelKeyPress += $handler
+[System.Console]::add_CancelKeyPress($handler)
 
 function Send-Error {
   param(
@@ -300,7 +302,7 @@ try {
   if ($listener.IsListening) {
     $listener.Stop()
   }
-  [Console]::CancelKeyPress -= $handler
+  [System.Console]::remove_CancelKeyPress($handler)
   if ($cancelled) {
     Write-Info "Servidor detenido."
   }


### PR DESCRIPTION
## Summary
- replace the previous CancelKeyPress subscription with a ConsoleCancelEventHandler
- ensure Ctrl+C stops the listener without throwing property errors

## Testing
- not run (non-applicable)

------
https://chatgpt.com/codex/tasks/task_e_68ebb7a99680832ab6a3f873ab7ec45a