### PR TITLE
Fix conda workflow setup

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -10,25 +10,21 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+    - name: Set up Miniconda with Python 3.10
+      uses: conda-incubator/setup-miniconda@v2
       with:
-        python-version: '3.10'
-    - name: Add conda to system path
-      run: |
-        # $CONDA is an environment variable pointing to the root of the miniconda directory
-        echo $CONDA/bin >> $GITHUB_PATH
+        python-version: "3.10"
+        auto-update-conda: true
+        use-mamba: false
     - name: Install dependencies
       run: |
-        conda env update --file environment.yml --name base
+        conda install --yes flake8 pytest
     - name: Lint with flake8
       run: |
-        conda install flake8
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        conda install pytest
         pytest


### PR DESCRIPTION
## Summary
- use conda-incubator/setup-miniconda to provision conda before running conda commands
- install flake8 and pytest directly instead of referencing a missing environment.yml

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68ebe13a7930832a9a9ded36af5ba957