### PR TITLE
Address review feedback for missing drive roots

### DIFF
--- a/tools/inventory-fileserver.ps1
+++ b/tools/inventory-fileserver.ps1
@@ -60,26 +60,34 @@ function Normalize-Root {
 
 $driveRoots = @{}
 
+function Add-DriveRoot {
+  param(
+    [string]$DriveKey,
+    [string]$Path
+  )
+
+  if ([string]::IsNullOrWhiteSpace($DriveKey)) {
+    return
+  }
+
+  $rootPath = Normalize-Root $Path
+  if ($rootPath) {
+    $normalizedKey = $DriveKey.TrimEnd(':').ToUpperInvariant()
+    $script:driveRoots[$normalizedKey] = $rootPath
+  }
+}
+
 if ($DriveMap -and $DriveMap.Keys.Count -gt 0) {
   foreach ($key in $DriveMap.Keys) {
-    $rootPath = Normalize-Root $DriveMap[$key]
-    if ($rootPath) {
-      $driveRoots[$key.ToString().TrimEnd(':').ToUpperInvariant()] = $rootPath
-    }
+    Add-DriveRoot -DriveKey $key.ToString() -Path $DriveMap[$key]
   }
 } elseif ($config -and $config.driveMappings) {
   foreach ($entry in $config.driveMappings.PSObject.Properties) {
-    $rootPath = Normalize-Root $entry.Value
-    if ($rootPath) {
-      $driveRoots[$entry.Name.TrimEnd(':').ToUpperInvariant()] = $rootPath
-    }
+    Add-DriveRoot -DriveKey $entry.Name -Path $entry.Value
   }
 } else {
   Get-PSDrive -PSProvider FileSystem | ForEach-Object {
-    $rootPath = Normalize-Root $_.Root
-    if ($rootPath) {
-      $driveRoots[$_.Name.ToUpperInvariant()] = $rootPath
-    }
+    Add-DriveRoot -DriveKey $_.Name -Path $_.Root
   }
 }
 


### PR DESCRIPTION
## Summary
- centralize drive root normalization into a helper that skips null mappings
- ensure autodiscovered PS drives are ignored when their root paths are unavailable

## Testing
- not run (PowerShell fileserver requires mapped drives that are unavailable in CI)


------
https://chatgpt.com/codex/tasks/task_e_68ebe6fc7650832a85b7dc3c3d4d5730