### PR TITLE
Configure CI to use conda environment file

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -5,26 +5,27 @@ on: [push]
 jobs:
   build-linux:
     runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 5
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Miniconda with Python 3.10
-      uses: conda-incubator/setup-miniconda@v2
-      with:
-        python-version: "3.10"
-        auto-update-conda: true
-        use-mamba: false
-    - name: Install dependencies
-      run: |
-        conda install --yes flake8 pytest
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
-      run: |
-        pytest
+      - uses: actions/checkout@v4
+
+      - name: Set up Miniconda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          python-version: "3.10"
+          environment-file: environment.yml
+          activate-environment: ci-env
+          use-mamba: true
+
+      - name: Lint with flake8
+        shell: bash -l {0}
+        run: |
+          which python
+          which flake8
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+      - name: Test with pytest
+        shell: bash -l {0}
+        run: |
+          pytest

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,8 @@
+name: ci-env
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.10
+  - flake8
+  - pytest


### PR DESCRIPTION
## Summary
- add a shared conda environment definition that includes Python 3.10, flake8, and pytest
- update the GitHub Actions workflow to create the conda environment with mamba and run steps in a login shell

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ebebfdccc0832ab3634dca61b857d9