### PR TITLE
Fix inventory cleaner wrappers for pwsh compatibility

### DIFF
--- a/tools/agents/inventory-cleaner.ps1
+++ b/tools/agents/inventory-cleaner.ps1
@@ -33,7 +33,7 @@ if ($SweepMode -ne "None") {
   $Sweep = Join-Path $RepoRoot "tools/agents/repo-sweep.ps1"
   if (Test-Path $Sweep) {
     Log "Running repo-sweep.ps1 ($SweepMode) ..."
-    powershell -NoProfile -ExecutionPolicy Bypass -File "$Sweep" -RepoRoot "$RepoRoot" -Mode "$SweepMode" 2>&1 | Tee-Object -FilePath $LogFile -Append
+    & $Sweep -RepoRoot "$RepoRoot" -Mode "$SweepMode" 2>&1 | Tee-Object -FilePath $LogFile -Append
   } else {
     Log "SKIP: tools/agents/repo-sweep.ps1 no encontrado"
   }
@@ -120,7 +120,7 @@ if (Test-Path $MakeInv) {
 
 if ($htmlGenerado -and (Test-Path $Wrapper)) {
   Log "Post-procesando inventario (wrapper)..."
-  powershell -NoProfile -ExecutionPolicy Bypass -File "$Wrapper" `
+  & $Wrapper `
     -RepoRoot "$RepoRoot" `
     -HtmlPath "$ExpectedHtml" `
     -CsvFallback "$csvDefault" `


### PR DESCRIPTION
## Summary
- invoke the repo sweep and wrapper scripts directly instead of shelling out to the Windows-only `powershell` executable so the cleaner works under `pwsh`

## Testing
- pwsh -NoProfile -ExecutionPolicy Bypass -File tools/agents/inventory-cleaner.ps1 -RepoRoot . -SweepMode None

------
https://chatgpt.com/codex/tasks/task_e_68ebfedb5ab0832a866c1d31cca28924