### PR TITLE
Fix repo sweep invocation to avoid exiting inventory cleaner

### DIFF
--- a/tools/agents/inventory-cleaner.ps1
+++ b/tools/agents/inventory-cleaner.ps1
@@ -32,8 +32,23 @@ Log "SweepMode: $SweepMode"
 if ($SweepMode -ne "None") {
   $Sweep = Join-Path $RepoRoot "tools/agents/repo-sweep.ps1"
   if (Test-Path $Sweep) {
-    Log "Running repo-sweep.ps1 ($SweepMode) ..."
-    & $Sweep -RepoRoot "$RepoRoot" -Mode "$SweepMode" 2>&1 | Tee-Object -FilePath $LogFile -Append
+    $psCmd = Get-Command -Name "pwsh" -ErrorAction SilentlyContinue
+    if (-not $psCmd) {
+      $psCmd = Get-Command -Name "powershell" -ErrorAction SilentlyContinue
+    }
+    if ($psCmd) {
+      Log "Running repo-sweep.ps1 ($SweepMode) ..."
+      $sweepArgs = @(
+        "-NoProfile",
+        "-ExecutionPolicy", "Bypass",
+        "-File", $Sweep,
+        "-RepoRoot", $RepoRoot,
+        "-Mode", $SweepMode
+      )
+      & $psCmd.Path @sweepArgs 2>&1 | Tee-Object -FilePath $LogFile -Append
+    } else {
+      Log "WARN: No se encontro pwsh/powershell para ejecutar repo-sweep.ps1"
+    }
   } else {
     Log "SKIP: tools/agents/repo-sweep.ps1 no encontrado"
   }

--- a/tools/agents/inventory-cleaner.ps1
+++ b/tools/agents/inventory-cleaner.ps1
@@ -45,7 +45,13 @@ if ($SweepMode -ne "None") {
         "-RepoRoot", $RepoRoot,
         "-Mode", $SweepMode
       )
-      & $psCmd.Path @sweepArgs 2>&1 | Tee-Object -FilePath $LogFile -Append
+      $sweepOutput = & $psCmd.Path @sweepArgs 2>&1
+      $sweepExit = $LASTEXITCODE
+      $sweepOutput | Tee-Object -FilePath $LogFile -Append
+      if ($sweepExit -ne 0) {
+        Log ("ERROR: repo-sweep.ps1 fallo con codigo {0}" -f $sweepExit)
+        throw "repo-sweep.ps1 termino con codigo $sweepExit"
+      }
     } else {
       Log "WARN: No se encontro pwsh/powershell para ejecutar repo-sweep.ps1"
     }


### PR DESCRIPTION
## Summary
- run repo-sweep.ps1 via an external pwsh/powershell process so exit calls do not terminate the cleaner
- fall back to Windows powershell when pwsh is unavailable and log when neither shell can be found

## Testing
- ⚠️ `pwsh -NoProfile -ExecutionPolicy Bypass -File tools/agents/inventory-cleaner.ps1 -RepoRoot . -SweepMode None` *(fails: pwsh not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ec0249e68c832aa8a8357e699451bb