### PR TITLE
Fix legacy CLI shim import path

### DIFF
--- a/tools/enrich_inventory_with_ai.py
+++ b/tools/enrich_inventory_with_ai.py
@@ -3,6 +3,15 @@
 
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
+
+_SRC_ROOT = Path(__file__).resolve().parents[1] / "src"
+if str(_SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SRC_ROOT))
+
+
 from discos_analisis.cli.enrich import main
 
 


### PR DESCRIPTION
## Summary
- add the repository's src directory to sys.path before importing discos_analisis in the legacy CLI shim

## Testing
- python tools/enrich_inventory_with_ai.py --help

------
https://chatgpt.com/codex/tasks/task_e_68ec51a735b4832a9e0e573f1421423b