### PR TITLE
Ensure hasher stream is disposed

### DIFF
--- a/tools/hash-drive-to-csv.ps1
+++ b/tools/hash-drive-to-csv.ps1
@@ -81,14 +81,16 @@ foreach ($item in (Get-ChildItem -LiteralPath $drivePath -Recurse -Force -File -
 
   $sha = ""
   if ($computeHash -and $hasher) {
+    $stream = $null
     try {
       $stream = $item.OpenRead()
       $hashBytes = $hasher.ComputeHash($stream)
-      $stream.Dispose()
       $sha = -join ($hashBytes | ForEach-Object { $_.ToString("x2") })
       $sha = $sha.ToUpperInvariant()
     } catch {
       Write-Warning ("No se pudo hashear {0}: {1}" -f $item.FullName, $_.Exception.Message)
+    } finally {
+      if ($stream) { $stream.Dispose() }
     }
   }
 


### PR DESCRIPTION
## Summary
- ensure the hashing stream is always disposed in tools/hash-drive-to-csv.ps1
- wrap ComputeHash usage in a try/finally to avoid handle leaks while keeping warnings

## Testing
- attempted to run `pwsh -NoProfile -ExecutionPolicy Bypass -File tools/hash-drive-to-csv.ps1 -Drive . -OutCsv tmp.csv -Algorithm None` (fails: `pwsh: command not found`)


------
https://chatgpt.com/codex/tasks/task_e_68ec6e43513c832ab4e269e57c6b5fa8