### PR TITLE
Fix legacy AI enrichment shim import path

### DIFF
--- a/tools/enrich_inventory_with_ai.py
+++ b/tools/enrich_inventory_with_ai.py
@@ -3,16 +3,32 @@
 
 from __future__ import annotations
 
+import importlib
 import sys
 from pathlib import Path
 
 
-_SRC_ROOT = Path(__file__).resolve().parents[1] / "src"
-if str(_SRC_ROOT) not in sys.path:
-    sys.path.insert(0, str(_SRC_ROOT))
+def _load_main() -> "object":
+    """Load `discos_analisis.cli.enrich.main` with fallback for src layout."""
+
+    try:
+        module = importlib.import_module("discos_analisis.cli.enrich")
+    except ModuleNotFoundError as first_error:
+        if first_error.name not in {"discos_analisis", "discos_analisis.cli", "discos_analisis.cli.enrich"}:
+            raise
+
+        repo_root = Path(__file__).resolve().parents[1]
+        src_dir = repo_root / "src"
+
+        if src_dir.is_dir() and str(src_dir) not in sys.path:
+            sys.path.insert(0, str(src_dir))
+
+        module = importlib.import_module("discos_analisis.cli.enrich")
+
+    return module.main
 
 
-from discos_analisis.cli.enrich import main
+main = _load_main()
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- load the CLI module through a helper that falls back to the local src/ tree when the package is not installed

## Testing
- python tools/enrich_inventory_with_ai.py --help

------
https://chatgpt.com/codex/tasks/task_e_68ec79eb2258832a9395e4e555b6e012