### PR TITLE
Handle AI tag generation compatibility

### DIFF
--- a/tools/build-inventory-html.ps1
+++ b/tools/build-inventory-html.ps1
@@ -616,11 +616,11 @@ $aiPayload = if ($EmbedBase64 -and $aiB64) {
 
 $aiTag = ""
 if ($aiPayload) {
-  $aiTag = "<script id=\"INV_AI_B64\" type=\"application/octet-stream\" data-src=\"data/inventory_ai_annotations.json\">" +
-    [Environment]::NewLine +
-    $aiPayload +
-    [Environment]::NewLine +
-    "</script>"
+  $aiBuilder = [System.Text.StringBuilder]::new()
+  [void]$aiBuilder.AppendLine('<script id="INV_AI_B64" type="application/octet-stream" data-src="data/inventory_ai_annotations.json">')
+  [void]$aiBuilder.AppendLine($aiPayload)
+  [void]$aiBuilder.Append('</script>')
+  $aiTag = $aiBuilder.ToString()
 }
 
 $tpl = $tpl.Replace("__B64__", $payload)


### PR DESCRIPTION
## Summary
- build the AI annotation script tag via a StringBuilder to avoid quoting issues when PowerShell parses the inventory HTML generator

## Testing
- not run (pwsh missing in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ec85b19fa4832aba5821ea8cf8ed69