### PR TITLE
Fix legacy shim path lookup for discos_analisis package

### DIFF
--- a/tools/enrich_inventory_with_ai.py
+++ b/tools/enrich_inventory_with_ai.py
@@ -4,26 +4,38 @@
 from __future__ import annotations
 
 import importlib
+import importlib.util
 import sys
 from pathlib import Path
+
+
+def _ensure_src_on_path() -> None:
+    """Insert the repository ``src`` directory into ``sys.path`` if present."""
+
+    repo_root = Path(__file__).resolve().parents[1]
+    src_dir = repo_root / "src"
+
+    if src_dir.is_dir() and str(src_dir) not in sys.path:
+        sys.path.insert(0, str(src_dir))
 
 
 def _load_main() -> "object":
     """Load `discos_analisis.cli.enrich.main` with fallback for src layout."""
 
+    module_name = "discos_analisis.cli.enrich"
+
+    if importlib.util.find_spec(module_name) is None:
+        _ensure_src_on_path()
+
     try:
-        module = importlib.import_module("discos_analisis.cli.enrich")
+        module = importlib.import_module(module_name)
     except ModuleNotFoundError as first_error:
         if first_error.name not in {"discos_analisis", "discos_analisis.cli", "discos_analisis.cli.enrich"}:
             raise
 
-        repo_root = Path(__file__).resolve().parents[1]
-        src_dir = repo_root / "src"
+        _ensure_src_on_path()
 
-        if src_dir.is_dir() and str(src_dir) not in sys.path:
-            sys.path.insert(0, str(src_dir))
-
-        module = importlib.import_module("discos_analisis.cli.enrich")
+        module = importlib.import_module(module_name)
 
     return module.main
 


### PR DESCRIPTION
## Summary
- extract the AI enrichment logic into a reusable `discos_analisis` Python package with dedicated modules
- provide a modern CLI entry point and packaging metadata via `pyproject.toml`
- keep the legacy `tools/enrich_inventory_with_ai.py` script as a thin shim for backwards compatibility
- ensure the legacy shim prepends the repository `src` directory to `sys.path` when running without an installed package

## Testing
- python -m compileall tools/enrich_inventory_with_ai.py

------
https://chatgpt.com/codex/tasks/task_e_68ec909c92e4832a93e0060c273bebb7