### PR TITLE
Improve legacy AI enrichment shim import resolution

### DIFF
--- a/tools/enrich_inventory_with_ai.py
+++ b/tools/enrich_inventory_with_ai.py
@@ -4,15 +4,40 @@
 from __future__ import annotations
 
 import sys
+from importlib import import_module
+from importlib.util import find_spec
 from pathlib import Path
 
 
-_SRC_ROOT = Path(__file__).resolve().parents[1] / "src"
-if str(_SRC_ROOT) not in sys.path:
-    sys.path.insert(0, str(_SRC_ROOT))
+def _ensure_src_on_path() -> None:
+    """Add the repository ``src`` directory to ``sys.path`` when available."""
+
+    src_root = Path(__file__).resolve().parents[1] / "src"
+    if not src_root.exists():
+        return
+
+    src_path = str(src_root)
+    if src_path not in sys.path:
+        sys.path.insert(0, src_path)
 
 
-from discos_analisis.cli.enrich import main
+def _resolve_main():
+    """Import the CLI entry point, adding ``src`` to ``sys.path`` as needed."""
+
+    spec = find_spec("discos_analisis")
+    if spec is None:
+        _ensure_src_on_path()
+        spec = find_spec("discos_analisis")
+        if spec is None:
+            raise ModuleNotFoundError(
+                "No se pudo importar 'discos_analisis'. Instala el paquete (p. ej. `pip install -e .`) "
+                "o ejecuta este script desde el repositorio que contiene el directorio `src/`."
+            )
+
+    return import_module("discos_analisis.cli.enrich").main
+
+
+main = _resolve_main()
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- only prepend the repository's `src/` directory when the `discos_analisis` package is not already importable
- resolve the CLI entrypoint via `importlib`, raising a clear guidance message when the package still cannot be located

## Testing
- python tools/enrich_inventory_with_ai.py --help

------
https://chatgpt.com/codex/tasks/task_e_68ec79da2310832ab0b35dbbe906c136