### PR TITLE
Fix legacy enrich shim module resolution

### DIFF
--- a/tools/enrich_inventory_with_ai.py
+++ b/tools/enrich_inventory_with_ai.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import importlib
-import importlib.util
 import sys
 from pathlib import Path
 
@@ -24,18 +23,12 @@ def _load_main() -> "object":
 
     module_name = "discos_analisis.cli.enrich"
 
-    if importlib.util.find_spec(module_name) is None:
-        _ensure_src_on_path()
+    # Ensure the development "src" tree is discoverable before attempting the import.
+    # This keeps the legacy entrypoint runnable from a fresh checkout without
+    # requiring `pip install -e .` or manual `PYTHONPATH` tweaks.
+    _ensure_src_on_path()
 
-    try:
-        module = importlib.import_module(module_name)
-    except ModuleNotFoundError as first_error:
-        if first_error.name not in {"discos_analisis", "discos_analisis.cli", "discos_analisis.cli.enrich"}:
-            raise
-
-        _ensure_src_on_path()
-
-        module = importlib.import_module(module_name)
+    module = importlib.import_module(module_name)
 
     return module.main
 


### PR DESCRIPTION
## Summary
- extract the AI enrichment logic into a reusable `discos_analisis` Python package with dedicated modules
- provide a modern CLI entry point and packaging metadata via `pyproject.toml`
- keep the legacy `tools/enrich_inventory_with_ai.py` script as a thin shim for backwards compatibility
- ensure the legacy shim injects the repository `src` directory into `sys.path` before importing the CLI module so it runs from a fresh checkout

## Testing
- python -m compileall src
- python - <<'PY'
import importlib.util
import pathlib
import sys

# Simulate executing from outside by dropping repo src path if present
sys.path = [p for p in sys.path if "src" not in p]

spec = importlib.util.spec_from_file_location(
    "legacy_enrich", pathlib.Path("tools/enrich_inventory_with_ai.py").resolve()
)
module = importlib.util.module_from_spec(spec)
spec.loader.exec_module(module)

main = module._load_main()
print(main.__module__)
PY

------
https://chatgpt.com/codex/tasks/task_e_68ec918bf1a0832aab50a415f7e86475