### PR TITLE
Fix legacy AI enrichment shim import path handling

### DIFF
--- a/tools/enrich_inventory_with_ai.py
+++ b/tools/enrich_inventory_with_ai.py
@@ -3,11 +3,8 @@
 
 from __future__ import annotations
 
-import importlib
-import importlib.util
 import sys
 from importlib import import_module
-from importlib.util import find_spec
 from pathlib import Path
 
 
@@ -26,17 +23,14 @@ def _ensure_src_on_path() -> None:
 def _resolve_main():
     """Import the CLI entry point, adding ``src`` to ``sys.path`` as needed."""
 
-    spec = find_spec("discos_analisis")
-    if spec is None:
-        _ensure_src_on_path()
-        spec = find_spec("discos_analisis")
-        if spec is None:
-            raise ModuleNotFoundError(
-                "No se pudo importar 'discos_analisis'. Instala el paquete (p. ej. `pip install -e .`) "
-                "o ejecuta este script desde el repositorio que contiene el directorio `src/`."
-            )
-
-    return import_module("discos_analisis.cli.enrich").main
+    _ensure_src_on_path()
+    try:
+        return import_module("discos_analisis.cli.enrich").main
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError(
+            "No se pudo importar 'discos_analisis'. Instala el paquete (p. ej. `pip install -e .`) "
+            "o ejecuta este script desde el repositorio que contiene el directorio `src/`."
+        ) from exc
 
 
 main = _resolve_main()


### PR DESCRIPTION
## Summary
- ensure the legacy enrich script adds the repository src directory to sys.path before importing the package
- raise a clearer error if the discos_analisis package still cannot be imported

## Testing
- python tools/enrich_inventory_with_ai.py --help

------
https://chatgpt.com/codex/tasks/task_e_68ec931a9598832a853de84142e42c96