### PR TITLE
Document legacy shim main loader resolution

### DIFF
--- a/tools/enrich_inventory_with_ai.py
+++ b/tools/enrich_inventory_with_ai.py
@@ -37,6 +37,7 @@ def _load_main() -> "object":
     return module.main
 
 
+# Resolve the CLI entry point at import time to mirror the legacy shim behaviour.
 main = _load_main()
 
 


### PR DESCRIPTION
## Summary
- document that the legacy shim resolves its CLI entry point through `_load_main()` to avoid regressions

## Testing
- python - <<'PY'
import importlib.util
import pathlib
import sys

sys.path = [p for p in sys.path if "src" not in p]

spec = importlib.util.spec_from_file_location(
    "legacy_enrich", pathlib.Path("tools/enrich_inventory_with_ai.py").resolve()
)
module = importlib.util.module_from_spec(spec)
spec.loader.exec_module(module)

main = module._load_main()
print(main.__module__)
PY

------
https://chatgpt.com/codex/tasks/task_e_68ec966808a0832ab75150de69e84113