### PR TITLE
Fix AI script tag quoting for offline HTML builder

### DIFF
--- a/tools/build-inventory-html.ps1
+++ b/tools/build-inventory-html.ps1
@@ -617,7 +617,7 @@ $aiPayload = if ($EmbedBase64 -and $aiB64) {
 $aiTag = ""
 if ($aiPayload) {
   $aiBuilder = [System.Text.StringBuilder]::new()
-  [void]$aiBuilder.AppendLine("<script id=""INV_AI_B64"" type=""application/octet-stream"" data-src=""data/inventory_ai_annotations.json"">")
+  [void]$aiBuilder.AppendLine('<script id="INV_AI_B64" type="application/octet-stream" data-src="data/inventory_ai_annotations.json"'>)
   [void]$aiBuilder.AppendLine($aiPayload)
   [void]$aiBuilder.Append('</script>')
   $aiTag = $aiBuilder.ToString()


### PR DESCRIPTION
## Summary
- generate the AI annotation script tag with literal double quotes while using the PowerShell string builder
- ensure the rendered `<script>` element exposes the expected id so downstream lookups continue to function

## Testing
- not run (PowerShell runtime unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68ec96756020832a95fa1244056aa485