### PR TITLE
Fix legacy shim import fallback for AI enrichment script

### DIFF
--- a/tools/enrich_inventory_with_ai.py
+++ b/tools/enrich_inventory_with_ai.py
@@ -33,7 +33,7 @@ def _load_main() -> "object":
         return import_module("discos_analisis.cli.enrich").main
 
 
-main = _resolve_main()
+main = _load_main()
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- ensure the legacy AI enrichment shim adds the repository `src` directory to `sys.path` when importing the CLI module
- wire the shim to invoke the `_load_main` helper so it can execute without installing the package

## Testing
- python tools/enrich_inventory_with_ai.py --help

------
https://chatgpt.com/codex/tasks/task_e_68ec96913b34832ab6bc5864df0b8bbc