### PR TITLE
Fix AI script tag quoting in HTML builder

### DIFF
--- a/tools/build-inventory-html.ps1
+++ b/tools/build-inventory-html.ps1
@@ -617,7 +617,7 @@ $aiPayload = if ($EmbedBase64 -and $aiB64) {
 $aiTag = ""
 if ($aiPayload) {
   $aiBuilder = [System.Text.StringBuilder]::new()
-  [void]$aiBuilder.AppendLine('<script id="INV_AI_B64" type="application/octet-stream" data-src="data/inventory_ai_annotations.json"'>)
+  [void]$aiBuilder.AppendLine("<script id=\"INV_AI_B64\" type=\"application/octet-stream\" data-src=\"data/inventory_ai_annotations.json\">")
   [void]$aiBuilder.AppendLine($aiPayload)
   [void]$aiBuilder.Append('</script>')
   $aiTag = $aiBuilder.ToString()


### PR DESCRIPTION
## Summary
- ensure the generated AI script tag uses properly quoted HTML attributes so the element id matches expectations

## Testing
- not run (pwsh missing in execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68ec984b03e4832a87977be484587d65