### PR TITLE
Fix legacy AI enrichment shim import handling

### DIFF
--- a/tools/enrich_inventory_with_ai.py
+++ b/tools/enrich_inventory_with_ai.py
@@ -21,7 +21,9 @@ def _ensure_src_on_path() -> None:
 
 
 def _load_main() -> "object":
-    """Load `discos_analisis.cli.enrich.main` with fallback for src layout."""
+    """Load `discos_analisis.cli.enrich.main` supporting editable checkouts."""
+
+    _ensure_src_on_path()
 
     try:
         return import_module("discos_analisis.cli.enrich").main
@@ -29,11 +31,13 @@ def _load_main() -> "object":
         if exc.name != "discos_analisis" and not exc.name.startswith("discos_analisis."):
             raise
 
-        _ensure_src_on_path()
-        return import_module("discos_analisis.cli.enrich").main
+        raise ModuleNotFoundError(
+            "No se pudo importar 'discos_analisis'. Instala el paquete o ejecuta el script "
+            "desde la raíz del repositorio."
+        ) from exc
 
 
-main = _resolve_main()
+main = _load_main()
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- ensure the legacy enrich script adds the src tree to sys.path before importing the package
- replace the bad _resolve_main reference with a correct _load_main binding and provide a clearer error message

## Testing
- python tools/enrich_inventory_with_ai.py --help

------
https://chatgpt.com/codex/tasks/task_e_68ec9682afe8832ab66f4942e8e97f7a