### PR TITLE
Address legacy enrich shim loader regression

### DIFF
--- a/tools/enrich_inventory_with_ai.py
+++ b/tools/enrich_inventory_with_ai.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import importlib
 import sys
-from importlib import import_module
 from pathlib import Path
 
 
@@ -36,7 +35,7 @@ def _load_main() -> "object":
     return module.main
 
 
-# Resolve the CLI entry point at import time to mirror the legacy shim behaviour.
+# Resolve the CLI entry point at import time using the loader helper.
 main = _load_main()
 
 


### PR DESCRIPTION
## Summary
- ensure the legacy shim resolves its CLI entry point via the renamed `_load_main` helper
- drop the unused `import_module` symbol that lingered after the loader refactor

## Testing
- python - <<'PY'
import importlib.util
import pathlib
import sys

sys.path = [p for p in sys.path if "src" not in p]

spec = importlib.util.spec_from_file_location(
    "legacy_enrich", pathlib.Path("tools/enrich_inventory_with_ai.py").resolve()
)
module = importlib.util.module_from_spec(spec)
spec.loader.exec_module(module)

main = module._load_main()
print(main.__module__)
PY

------
https://chatgpt.com/codex/tasks/task_e_68ec98bbe3c0832ab080b4c7465dfc12