### PR TITLE
Fix AI script tag quoting in offline AI payload injection

### DIFF
--- a/tools/build-inventory-html.ps1
+++ b/tools/build-inventory-html.ps1
@@ -617,7 +617,7 @@ $aiPayload = if ($EmbedBase64 -and $aiB64) {
 $aiTag = ""
 if ($aiPayload) {
   $aiBuilder = [System.Text.StringBuilder]::new()
-  [void]$aiBuilder.AppendLine("<script id=`"INV_AI_B64`" type=`"application/octet-stream`" data-src=`"data/inventory_ai_annotations.json`">")
+  [void]$aiBuilder.AppendLine('<script id="INV_AI_B64" type="application/octet-stream" data-src="data/inventory_ai_annotations.json">')
   [void]$aiBuilder.AppendLine($aiPayload)
   [void]$aiBuilder.Append('</script>')
   $aiTag = $aiBuilder.ToString()


### PR DESCRIPTION
## Summary
- ensure the AI payload script tag uses literal double quotes when emitted so downstream lookup works correctly

## Testing
- not run (pwsh unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ec9b10a5b8832aa3e5cc3ec12ea63a