### PR TITLE
Fix legacy shim main loader call

### DIFF
--- a/tools/enrich_inventory_with_ai.py
+++ b/tools/enrich_inventory_with_ai.py
@@ -38,6 +38,9 @@ def _load_main() -> "object":
 # Resolve the CLI entry point at import time using the loader helper.
 main = _load_main()
 
+# Backwards compatibility for callers that imported the previous helper name.
+_resolve_main = _load_main
+
 
 if __name__ == "__main__":  # pragma: no cover
     try:


### PR DESCRIPTION
## Summary
- ensure the legacy enrich shim resolves the CLI entry point with the renamed loader helper
- expose `_resolve_main` as a compatibility alias for downstream callers

## Testing
- python - <<'PY'
import importlib.util
import pathlib
import sys

sys.path = [p for p in sys.path if "src" not in p]

spec = importlib.util.spec_from_file_location(
    "legacy_enrich", pathlib.Path("tools/enrich_inventory_with_ai.py").resolve()
)
module = importlib.util.module_from_spec(spec)
spec.loader.exec_module(module)

main = module.main
print(main.__module__)
print(module._resolve_main() is main)
PY

------
https://chatgpt.com/codex/tasks/task_e_68ec9c1208e8832a96bdcaca13e0decb