### PR TITLE
Fix legacy enrich shim module resolution

### DIFF
--- a/tools/enrich_inventory_with_ai.py
+++ b/tools/enrich_inventory_with_ai.py
@@ -38,8 +38,11 @@ def _load_main() -> "object":
 # Resolve the CLI entry point at import time using the loader helper.
 main = _load_main()
 
-# Backwards compatibility for callers that imported the previous helper name.
-_resolve_main = _load_main
+
+def _resolve_main() -> "object":
+    """Compatibility shim for legacy callers expecting the old helper name."""
+
+    return _load_main()
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- fix the legacy shim to resolve the CLI entry point using the renamed `_load_main` helper
- provide a compatibility wrapper so existing imports of `_resolve_main()` continue to work without NameErrors

## Testing
- python - <<'PY'
import importlib.util
import pathlib
import sys

# Simulate executing from outside by dropping repo src path if present
sys.path = [p for p in sys.path if "src" not in p]

spec = importlib.util.spec_from_file_location(
    "legacy_enrich", pathlib.Path("tools/enrich_inventory_with_ai.py").resolve()
)
module = importlib.util.module_from_spec(spec)
spec.loader.exec_module(module)

main = module._load_main()
print(main.__module__)
print(module.main is main)
print(module._resolve_main().__module__)
PY

------
https://chatgpt.com/codex/tasks/task_e_68ec9cbbbdac832ab4c65babfa1e3fd4