### PR TITLE
Fix legacy AI enrichment shim import path

### DIFF
--- a/tools/enrich_inventory_with_ai.py
+++ b/tools/enrich_inventory_with_ai.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import importlib
 import sys
 from importlib import import_module
 from pathlib import Path
@@ -24,8 +23,6 @@ def _ensure_src_on_path() -> None:
 def _load_main() -> "object":
     """Load `discos_analisis.cli.enrich.main` supporting editable checkouts."""
 
-    _ensure_src_on_path()
-
     module_name = "discos_analisis.cli.enrich"
 
     # Ensure the development "src" tree is discoverable before attempting the import.
@@ -33,12 +30,21 @@ def _load_main() -> "object":
     # requiring `pip install -e .` or manual `PYTHONPATH` tweaks.
     _ensure_src_on_path()
 
-    module = importlib.import_module(module_name)
-
+    try:
+        module = import_module(module_name)
+    except ModuleNotFoundError as exc:  # pragma: no cover - defensive path
         raise ModuleNotFoundError(
             "No se pudo importar 'discos_analisis'. Instala el paquete o ejecuta el script "
             "desde la raíz del repositorio."
         ) from exc
+
+    main_attr = getattr(module, "main", None)
+    if main_attr is None:
+        raise AttributeError(
+            "El módulo 'discos_analisis.cli.enrich' no expone un callable 'main'."
+        )
+
+    return main_attr
 
 
 main = _load_main()


### PR DESCRIPTION
## Summary
- extract the AI enrichment logic into a reusable `discos_analisis` Python package with dedicated modules
- provide a modern CLI entry point and packaging metadata via `pyproject.toml`
- keep the legacy `tools/enrich_inventory_with_ai.py` script as a thin shim for backwards compatibility
- ensure the legacy shim adds `src/` to `sys.path` so it works from a fresh checkout

## Testing
- python -m compileall src
- python tools/enrich_inventory_with_ai.py --help

------
https://chatgpt.com/codex/tasks/task_e_68ec9de6a630832aa39f59e7e60c2929