### PR TITLE
Fix legacy enrich shim module resolution

### DIFF
--- a/tools/enrich_inventory_with_ai.py
+++ b/tools/enrich_inventory_with_ai.py
@@ -35,14 +35,15 @@ def _load_main() -> "object":
     return module.main
 
 
-# Resolve the CLI entry point at import time using the loader helper.
-main = _load_main()
-
-
+# Keep a compatibility helper for callers that previously imported `_resolve_main`.
 def _resolve_main() -> "object":
     """Compatibility shim for legacy callers expecting the old helper name."""
 
     return _load_main()
+
+
+# Resolve the CLI entry point at import time using the loader helper.
+main = _load_main()
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- extract the AI enrichment logic into a reusable `discos_analisis` Python package with dedicated modules
- provide a modern CLI entry point and packaging metadata via `pyproject.toml`
- keep the legacy `tools/enrich_inventory_with_ai.py` script as a thin shim for backwards compatibility
- ensure the legacy shim injects the repository `src` directory into `sys.path` before importing the CLI module so it runs from a fresh checkout
- fix the legacy shim to resolve the CLI entry point via `_load_main()` so the module imports without a `NameError`

## Testing
- python -m compileall src
- PYTHONDONTWRITEBYTECODE=1 python - <<'PY'
import importlib.util
import pathlib
import sys

sys.path = [p for p in sys.path if "src" not in p]

spec = importlib.util.spec_from_file_location(
    "legacy_enrich", pathlib.Path("tools/enrich_inventory_with_ai.py").resolve()
)
module = importlib.util.module_from_spec(spec)
spec.loader.exec_module(module)

print(module.main.__name__)
print(module.main.__module__)
PY


------
https://chatgpt.com/codex/tasks/task_e_68ec9f35ce5c832aac2ef962dbf42d32