### PR TITLE
Fix legacy enrich shim module resolution follow-up

### DIFF
--- a/tools/enrich_inventory_with_ai.py
+++ b/tools/enrich_inventory_with_ai.py
@@ -35,15 +35,15 @@ def _load_main() -> "object":
     return module.main
 
 
+# Resolve the CLI entry point at import time using the loader helper.
+main = _load_main()
+
+
 # Keep a compatibility helper for callers that previously imported `_resolve_main`.
 def _resolve_main() -> "object":
     """Compatibility shim for legacy callers expecting the old helper name."""
 
-    return _load_main()
-
-
-# Resolve the CLI entry point at import time using the loader helper.
-main = _load_main()
+    return main
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- resolve the legacy enrich shim entry point using the new `_load_main` helper at import time
- return the cached `main` callable from `_resolve_main` to keep backwards compatibility without reloading the module

## Testing
- python - <<'PY'
import importlib.util
import pathlib
import sys

sys.path = [p for p in sys.path if "src" not in p]

spec = importlib.util.spec_from_file_location(
    "legacy_enrich", pathlib.Path("tools/enrich_inventory_with_ai.py").resolve()
)
module = importlib.util.module_from_spec(spec)
spec.loader.exec_module(module)

main = module.main
print(main.__module__)
print(module._resolve_main() is main)
PY

------
https://chatgpt.com/codex/tasks/task_e_68eca087188c832a8cf5e8556b6ea821