### PR TITLE
Fix AI script tag quoting to emit valid attributes

### DIFF
--- a/tools/build-inventory-html.ps1
+++ b/tools/build-inventory-html.ps1
@@ -617,7 +617,7 @@ $aiPayload = if ($EmbedBase64 -and $aiB64) {
 $aiTag = ""
 if ($aiPayload) {
   $aiBuilder = [System.Text.StringBuilder]::new()
-  [void]$aiBuilder.AppendLine('<script id="INV_AI_B64" type="application/octet-stream" data-src="data/inventory_ai_annotations.json">')
+  [void]$aiBuilder.AppendLine("<script id=`"INV_AI_B64`" type=`"application/octet-stream`" data-src=`"data/inventory_ai_annotations.json`">")
   [void]$aiBuilder.AppendLine($aiPayload)
   [void]$aiBuilder.Append('</script>')
   $aiTag = $aiBuilder.ToString()


### PR DESCRIPTION
## Summary
- ensure the AI base64 script tag is appended with plain double quotes so browsers can resolve the element id

## Testing
- not run (pwsh missing in execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68eca0433eac832ab3a019e02b760405