### PR TITLE
Follow-up: restore legacy enrich shim main loader alias

### DIFF
--- a/tools/enrich_inventory_with_ai.py
+++ b/tools/enrich_inventory_with_ai.py
@@ -43,7 +43,7 @@ main = _load_main()
 def _resolve_main() -> "object":
     """Compatibility shim for legacy callers expecting the old helper name."""
 
-    return main
+    return _load_main()
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- ensure the legacy `_resolve_main` helper invokes `_load_main()` so the shim imports without raising a NameError

## Testing
- python - <<'PY'
import importlib.util
import pathlib
import sys

sys.path = [p for p in sys.path if "src" not in p]

spec = importlib.util.spec_from_file_location(
    "legacy_enrich", pathlib.Path("tools/enrich_inventory_with_ai.py").resolve()
)
module = importlib.util.module_from_spec(spec)
spec.loader.exec_module(module)

main = module._load_main()
print(main.__module__)
print(module._resolve_main().__module__)
PY

------
https://chatgpt.com/codex/tasks/task_e_68eca67915a8832a8aa560e82337308e