### PR TITLE
Fix legacy shim main loader alias

### DIFF
--- a/tools/enrich_inventory_with_ai.py
+++ b/tools/enrich_inventory_with_ai.py
@@ -47,7 +47,7 @@ main: MainCallable = _load_main()
 def _resolve_main() -> MainCallable:
     """Compatibility shim for legacy callers expecting the old helper name."""
 
-    return _load_main()
+    return main
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- return the cached CLI entry point from the `_resolve_main` compatibility helper so module import succeeds after renaming

## Testing
- python -m compileall tools/enrich_inventory_with_ai.py

------
https://chatgpt.com/codex/tasks/task_e_68eca729d910832aa46b8ab636d2837f