### PR TITLE
Refactor OpenAI enrichment into reusable package

### DIFF
--- a/tools/enrich_inventory_with_ai.py
+++ b/tools/enrich_inventory_with_ai.py
@@ -4,8 +4,13 @@
 from __future__ import annotations
 
 import sys
+from collections.abc import Callable
 from importlib import import_module
 from pathlib import Path
+from types import ModuleType
+
+
+_MainCallable = Callable[[], int | None]
 
 
 def _ensure_src_on_path() -> None:
@@ -20,18 +25,18 @@ def _ensure_src_on_path() -> None:
         sys.path.insert(0, src_path)
 
 
-def _load_main() -> "object":
-    """Load `discos_analisis.cli.enrich.main` supporting editable checkouts."""
+def _load_main() -> _MainCallable:
+    """Load ``discos_analisis.cli.enrich.main`` supporting editable checkouts."""
 
     module_name = "discos_analisis.cli.enrich"
 
-    # Ensure the development "src" tree is discoverable before attempting the import.
-    # This keeps the legacy entrypoint runnable from a fresh checkout without
-    # requiring `pip install -e .` or manual `PYTHONPATH` tweaks.
+    # Ensure the development ``src`` tree is discoverable before attempting the
+    # import. This keeps the legacy entrypoint runnable from a fresh checkout
+    # without requiring ``pip install -e .`` or manual ``PYTHONPATH`` tweaks.
     _ensure_src_on_path()
 
     try:
-        module = import_module(module_name)
+        module: ModuleType = import_module(module_name)
     except ModuleNotFoundError as exc:  # pragma: no cover - defensive path
         raise ModuleNotFoundError(
             "No se pudo importar 'discos_analisis'. Instala el paquete o ejecuta el script "
@@ -39,7 +44,7 @@ def _load_main() -> "object":
         ) from exc
 
     main_attr = getattr(module, "main", None)
-    if main_attr is None:
+    if not isinstance(main_attr, Callable):
         raise AttributeError(
             "El módulo 'discos_analisis.cli.enrich' no expone un callable 'main'."
         )


### PR DESCRIPTION
## Summary
- extract the AI enrichment logic into a reusable `discos_analisis` Python package with dedicated modules
- provide a modern CLI entry point and packaging metadata via `pyproject.toml`
- keep the legacy `tools/enrich_inventory_with_ai.py` script as a thin shim for backwards compatibility
- ensure the legacy shim automatically exposes the repository `src` tree on `sys.path` so it runs from a fresh checkout

## Testing
- python -m compileall src
- python -m compileall tools/enrich_inventory_with_ai.py

------
https://chatgpt.com/codex/tasks/task_e_68eca5cb06ac832ab3ce59b5fa47a9c6