### PR TITLE
Fix AI script tag quoting for AI script block

### DIFF
--- a/tools/build-inventory-html.ps1
+++ b/tools/build-inventory-html.ps1
@@ -617,7 +617,7 @@ $aiPayload = if ($EmbedBase64 -and $aiB64) {
 $aiTag = ""
 if ($aiPayload) {
   $aiBuilder = [System.Text.StringBuilder]::new()
-  [void]$aiBuilder.AppendLine('<script id="INV_AI_B64" type="application/octet-stream" data-src="data/inventory_ai_annotations.json">')
+  [void]$aiBuilder.AppendLine("<script id=""INV_AI_B64"" type=""application/octet-stream"" data-src=""data/inventory_ai_annotations.json"">")
   [void]$aiBuilder.AppendLine($aiPayload)
   [void]$aiBuilder.Append('</script>')
   $aiTag = $aiBuilder.ToString()


### PR DESCRIPTION
## Summary
- ensure the AI script tag is emitted with literal double-quoted attributes so the DOM id is set correctly

## Testing
- not run (no automated tests available)


------
https://chatgpt.com/codex/tasks/task_e_68ecacc42134832ab770a655b092b888