### PR TITLE
Fix legacy enrich shim loader invocation

### DIFF
--- a/tools/enrich_inventory_with_ai.py
+++ b/tools/enrich_inventory_with_ai.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import sys
+from importlib import import_module
 from pathlib import Path
 from typing import Callable, Final, Optional
 
@@ -58,7 +59,7 @@ main: Final[MainCallable] = _load_main()
 def _resolve_main() -> MainCallable:
     """Compatibility shim for legacy callers expecting the old helper name."""
 
-    return _load_main()
+    return main
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- import `import_module` so the shim can load the packaged CLI module
- return the cached `main` callable from `_resolve_main()` for backwards compatibility

## Testing
- python - <<'PY'
import importlib.util
import pathlib
import sys

sys.path = [p for p in sys.path if "src" not in p]

spec = importlib.util.spec_from_file_location(
    "legacy_enrich", pathlib.Path("tools/enrich_inventory_with_ai.py").resolve()
)
module = importlib.util.module_from_spec(spec)
spec.loader.exec_module(module)

main = module.main
print(main)
print(module._resolve_main())
PY

------
https://chatgpt.com/codex/tasks/task_e_68ecad808320832aaaf553e47fa01c0f