### PR TITLE
Fix Codex review issues for "Fix legacy enrich shim module resolution"

### DIFF
--- a/tools/enrich_inventory_with_ai.py
+++ b/tools/enrich_inventory_with_ai.py
@@ -52,7 +52,8 @@ def _load_main() -> MainCallable:
 
 
 # Resolve the CLI entry point at import time using the loader helper.
-main: Final[MainCallable] = _load_main()
+main: Final[MainCallable]
+main = _load_main()
 
 
 # Keep a compatibility helper for callers that previously imported `_resolve_main`.


### PR DESCRIPTION
## Summary
- update the legacy enrich shim to initialize `main` by calling the renamed `_load_main()` helper

## Testing
- python -m compileall tools/enrich_inventory_with_ai.py

------
https://chatgpt.com/codex/tasks/task_e_68ecb121bd44832a93fa68efec4778c8