### PR TITLE
Ensure legacy AI shim bootstraps src path for editable checkouts

### DIFF
--- a/tools/enrich_inventory_with_ai.py
+++ b/tools/enrich_inventory_with_ai.py
@@ -8,9 +8,12 @@ from collections.abc import Callable
 from importlib import import_module
 from pathlib import Path
 from types import ModuleType
+from typing import Final
 
 
 _MainCallable = Callable[[], int | None]
+# Exported for compatibility with legacy callers that imported ``MainCallable``.
+MainCallable = _MainCallable
 
 
 def _ensure_src_on_path() -> Path | None:
@@ -49,7 +52,7 @@ def _load_main() -> _MainCallable:
     # Ensure the development ``src`` tree is discoverable before attempting the
     # import. This keeps the legacy entrypoint runnable from a fresh checkout
     # without requiring ``pip install -e .`` or manual ``PYTHONPATH`` tweaks.
-    src_root = _SRC_ROOT or _ensure_src_on_path()
+    src_root = _ensure_src_on_path() or _SRC_ROOT
 
     try:
         module: ModuleType = import_module(module_name)


### PR DESCRIPTION
## Summary
- ensure the legacy `tools/enrich_inventory_with_ai.py` shim re-adds the repository `src/` directory to `sys.path` before resolving the package entry point
- export the historical `MainCallable` alias for compatibility with callers still importing it

## Testing
- python tools/enrich_inventory_with_ai.py --help

------
https://chatgpt.com/codex/tasks/task_e_68ecb1a29010832aaf57f0282c0e73bd