### PR TITLE
Fix legacy shim main loader assignment

### DIFF
--- a/tools/enrich_inventory_with_ai.py
+++ b/tools/enrich_inventory_with_ai.py
@@ -52,8 +52,7 @@ def _load_main() -> MainCallable:
 
 
 # Resolve the CLI entry point at import time using the loader helper.
-main: Final[MainCallable]
-main = _load_main()
+main: Final[MainCallable] = _load_main()
 
 
 # Keep a compatibility helper for callers that previously imported `_resolve_main`.


### PR DESCRIPTION
## Summary
- extract the AI enrichment logic into a reusable `discos_analisis` Python package with dedicated modules
- provide a modern CLI entry point and packaging metadata via `pyproject.toml`
- keep the legacy `tools/enrich_inventory_with_ai.py` script as a thin shim for backwards compatibility
- ensure the legacy shim injects the repository `src` directory into `sys.path` before importing the CLI module so it runs from a fresh checkout
- fix the legacy shim to resolve the CLI callable using `_load_main()` after the helper rename

## Testing
- python - <<'PY'
import importlib.util
import pathlib
import sys

# Simulate executing from outside by dropping repo src path if present
sys.path = [p for p in sys.path if "src" not in p]

spec = importlib.util.spec_from_file_location(
    "legacy_enrich", pathlib.Path("tools/enrich_inventory_with_ai.py").resolve()
)
module = importlib.util.module_from_spec(spec)
spec.loader.exec_module(module)

main = module._load_main()
print(main.__module__)
PY

------
https://chatgpt.com/codex/tasks/task_e_68ecb3ed2204832aaf8a071f04885625