### PR TITLE
Address legacy enrich shim import regression

### DIFF
--- a/tools/enrich_inventory_with_ai.py
+++ b/tools/enrich_inventory_with_ai.py
@@ -11,6 +11,9 @@ from types import ModuleType
 from typing import Final
 
 
+_ENTRYPOINT: Final[str] = "discos_analisis.cli.enrich"
+
+
 _MainCallable = Callable[[], int | None]
 # Exported for compatibility with legacy callers that imported ``MainCallable``.
 MainCallable = _MainCallable


### PR DESCRIPTION
## Summary
- define the CLI entry point string so the legacy shim can import the reusable package
- rely on the helper that amends `sys.path` to keep `tools/enrich_inventory_with_ai.py` runnable from a fresh checkout

## Testing
- python -m compileall tools/enrich_inventory_with_ai.py
- python tools/enrich_inventory_with_ai.py --help

------
https://chatgpt.com/codex/tasks/task_e_68ecb5d4910c832a860387a1baa691e6