### PR TITLE
Fix legacy enrich shim imports

### DIFF
--- a/tools/enrich_inventory_with_ai.py
+++ b/tools/enrich_inventory_with_ai.py
@@ -11,6 +11,9 @@ from types import ModuleType
 from typing import Final
 
 
+_ENTRYPOINT: Final[str] = "discos_analisis.cli.enrich"
+
+
 _MainCallable = Callable[[], int | None]
 # Exported for compatibility with legacy callers that imported ``MainCallable``.
 MainCallable = _MainCallable


### PR DESCRIPTION
## Summary
- define the CLI entry point constant used by the legacy shim so it can import the packaged CLI module
- keep the direct `python tools/enrich_inventory_with_ai.py` invocation working without requiring the package to be installed

## Testing
- python tools/enrich_inventory_with_ai.py --help

------
https://chatgpt.com/codex/tasks/task_e_68ecb5b56208832aa9c99e2345483c8c