### PR TITLE
Handle offline HTML opener cross-platform

### DIFF
--- a/tools/build-inventory-html.ps1
+++ b/tools/build-inventory-html.ps1
@@ -617,7 +617,7 @@ $aiPayload = if ($EmbedBase64 -and $aiB64) {
 $aiTag = ""
 if ($aiPayload) {
   $aiBuilder = [System.Text.StringBuilder]::new()
-  [void]$aiBuilder.AppendLine("<script id=""INV_AI_B64"" type=""application/octet-stream"" data-src=""data/inventory_ai_annotations.json"">")
+  [void]$aiBuilder.AppendLine('<script id="INV_AI_B64" type="application/octet-stream" data-src="data/inventory_ai_annotations.json">')
   [void]$aiBuilder.AppendLine($aiPayload)
   [void]$aiBuilder.Append('</script>')
   $aiTag = $aiBuilder.ToString()


### PR DESCRIPTION
## Summary
- add platform-aware logic when opening the generated offline HTML so Windows, macOS, and Linux behave appropriately
- emit a warning when no opener is available on Unix hosts instead of throwing a fatal error
- fix AI annotation script tag quoting so the generated HTML includes valid attributes

## Testing
- not run (pwsh missing in execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68ecb6efc19c832aa6a6075b985e9900