### PR TITLE
Fix legacy shim main loader resolution follow-up

### DIFF
--- a/tools/enrich_inventory_with_ai.py
+++ b/tools/enrich_inventory_with_ai.py
@@ -52,7 +52,8 @@ def _load_main() -> MainCallable:
 
 
 # Resolve the CLI entry point at import time using the new `_load_main` helper.
-main: Final[MainCallable] = _load_main()
+main: Final[MainCallable]
+main = _load_main()
 
 
 # Keep a compatibility helper for callers that previously imported `_resolve_main`.


### PR DESCRIPTION
## Summary
- initialize the legacy shim's `main` binding via the renamed `_load_main()` helper while preserving the `Final` annotation
- retain the `_resolve_main` compatibility wrapper so legacy imports continue to work

## Testing
- python tools/enrich_inventory_with_ai.py

------
https://chatgpt.com/codex/tasks/task_e_68ecb690d298832aa65401c40fb20e6a