### PR TITLE
Fix legacy AI enrichment shim import path

### DIFF
--- a/tools/enrich_inventory_with_ai.py
+++ b/tools/enrich_inventory_with_ai.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import sys
 from collections.abc import Callable
+from functools import lru_cache
 from importlib import import_module
 from pathlib import Path
 from types import ModuleType
@@ -19,6 +20,7 @@ _MainCallable = Callable[[], int | None]
 MainCallable = _MainCallable
 
 
+@lru_cache(maxsize=1)
 def _ensure_src_on_path() -> Path | None:
     """Ensure the development ``src`` tree is importable.
 


### PR DESCRIPTION
## Summary
- ensure the legacy `tools/enrich_inventory_with_ai.py` shim prepends the development `src` directory to `sys.path`
- cache the helper so the `src` directory is only added once when legacy callers import the module repeatedly

## Testing
- python tools/enrich_inventory_with_ai.py --help

------
https://chatgpt.com/codex/tasks/task_e_68ecb88dcffc832a9647162e0fdc7f3d