### PR TITLE
Fix legacy enrich shim main loader alias

### DIFF
--- a/tools/enrich_inventory_with_ai.py
+++ b/tools/enrich_inventory_with_ai.py
@@ -52,14 +52,15 @@ def _load_main() -> MainCallable:
 
 
 # Resolve the CLI entry point at import time using the new `_load_main` helper.
-main: Final[MainCallable] = _load_main()
+main: Final[MainCallable]
+main = _load_main()
 
 
 # Keep a compatibility helper for callers that previously imported `_resolve_main`.
 def _resolve_main() -> MainCallable:
     """Compatibility shim for legacy callers expecting the old helper name."""
 
-    return main
+    return _load_main()
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- resolve the legacy shim's module-level `main` reference through the renamed `_load_main()` helper
- update the `_resolve_main()` compatibility shim to delegate to `_load_main()` so legacy imports reuse the new loader

## Testing
- python - <<'PY'
import importlib.util
import pathlib
import sys

# Simulate environment without repo src path
sys.path = [p for p in sys.path if 'src' not in p]

spec = importlib.util.spec_from_file_location(
    "legacy_enrich", pathlib.Path("tools/enrich_inventory_with_ai.py").resolve()
)
module = importlib.util.module_from_spec(spec)
spec.loader.exec_module(module)

print(module.main.__module__)
print(module._resolve_main().__module__)
PY

------
https://chatgpt.com/codex/tasks/task_e_68ecb9f21cf8832abe5146a0114d7e06