### PR TITLE
Fix legacy shim main resolution follow-up

### DIFF
--- a/tools/enrich_inventory_with_ai.py
+++ b/tools/enrich_inventory_with_ai.py
@@ -59,7 +59,7 @@ main: Final[MainCallable] = _load_main()
 def _resolve_main() -> MainCallable:
     """Compatibility shim for legacy callers expecting the old helper name."""
 
-    return _load_main()
+    return main
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- ensure the legacy shim's compatibility helper returns the resolved `_load_main` callable so `_resolve_main()` remains usable after the rename

## Testing
- python - <<'PY'
import importlib.util
import pathlib
import sys

sys.path = [p for p in sys.path if "src" not in p]

spec = importlib.util.spec_from_file_location(
    "legacy_enrich", pathlib.Path("tools/enrich_inventory_with_ai.py").resolve()
)
module = importlib.util.module_from_spec(spec)
spec.loader.exec_module(module)

main = module._resolve_main()
print(main.__module__)
PY

------
https://chatgpt.com/codex/tasks/task_e_68ecbcd53464832ab8dca4e931e8c542