### PR TITLE
Fix legacy enrich shim loader regression

### DIFF
--- a/tools/enrich_inventory_with_ai.py
+++ b/tools/enrich_inventory_with_ai.py
@@ -79,8 +79,6 @@ def _load_main() -> _MainCallable:
     return main_attr
 
 
-# Resolve the CLI entry point at import time using the new `_load_main` helper.
-main: Final[MainCallable] = _load_main()
 # Resolve the CLI entry point at import time using the loader helper.
 main: Final[_MainCallable] = _load_main()
 


### PR DESCRIPTION
## Summary
- update the legacy shim to initialize `main` using the new `_load_main()` helper

## Testing
- python - <<'PY'
import importlib.util
import pathlib
import sys

sys.path = [p for p in sys.path if "src" not in p]

spec = importlib.util.spec_from_file_location(
    "legacy_enrich", pathlib.Path("tools/enrich_inventory_with_ai.py").resolve()
)
module = importlib.util.module_from_spec(spec)
spec.loader.exec_module(module)

main = module._load_main()
print(main.__module__)
PY

------
https://chatgpt.com/codex/tasks/task_e_68ecc0b9c7e4832a9f76e21ba326643a