### PR TITLE
Fix AI annotation script tag quoting

### DIFF
--- a/tools/build-inventory-html.ps1
+++ b/tools/build-inventory-html.ps1
@@ -617,7 +617,7 @@ $aiPayload = if ($EmbedBase64 -and $aiB64) {
 $aiTag = ""
 if ($aiPayload) {
   $aiBuilder = [System.Text.StringBuilder]::new()
-  [void]$aiBuilder.AppendLine('<script id="INV_AI_B64" type="application/octet-stream" data-src="data/inventory_ai_annotations.json">')
+  [void]$aiBuilder.AppendLine("<script id=`"INV_AI_B64`" type=`"application/octet-stream`" data-src=`"data/inventory_ai_annotations.json`">")
   [void]$aiBuilder.AppendLine($aiPayload)
   [void]$aiBuilder.Append('</script>')
   $aiTag = $aiBuilder.ToString()


### PR DESCRIPTION
## Summary
- fix the AI annotation script block builder to emit literal double quotes instead of escaped characters

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68ecc124a67c832a8806978ff5f49548