### PR TITLE
Fix legacy shim main loader call

### DIFF
--- a/tools/enrich_inventory_with_ai.py
+++ b/tools/enrich_inventory_with_ai.py
@@ -79,7 +79,7 @@ def _load_main() -> _MainCallable:
     return main_attr
 
 
-# Resolve the CLI entry point at import time using the loader helper.
+# Resolve the CLI entry point at import time using the new ``_load_main`` helper.
 main: Final[_MainCallable] = _load_main()
 
 


### PR DESCRIPTION
## Summary
- extract the AI enrichment logic into a reusable `discos_analisis` Python package with dedicated modules
- provide a modern CLI entry point and packaging metadata via `pyproject.toml`
- keep the legacy `tools/enrich_inventory_with_ai.py` script as a thin shim for backwards compatibility
- ensure the legacy shim injects the repository `src` directory into `sys.path` before importing the CLI module so it runs from a fresh checkout
- fix the module-level entry point resolution to use the new `_load_main` helper

## Testing
- python -m compileall src
- python - <<'PY'
import importlib.util
import pathlib
import sys

# Simulate executing from outside by dropping repo src path if present
sys.path = [p for p in sys.path if "src" not in p]

spec = importlib.util.spec_from_file_location(
    "legacy_enrich", pathlib.Path("tools/enrich_inventory_with_ai.py").resolve()
)
module = importlib.util.module_from_spec(spec)
spec.loader.exec_module(module)

main = module._load_main()
print(main.__module__)
PY

------
https://chatgpt.com/codex/tasks/task_e_68ecc1911fac832a9ccd31aa60379ace