### PR TITLE
Ensure legacy enrich shim loads renamed entry point

### DIFF
--- a/tools/enrich_inventory_with_ai.py
+++ b/tools/enrich_inventory_with_ai.py
@@ -87,7 +87,7 @@ main: Final[_MainCallable] = _load_main()
 def _resolve_main() -> _MainCallable:
     """Compatibility shim for legacy callers expecting the old helper name."""
 
-    return main
+    return _load_main()
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- ensure the legacy shim resolves its CLI entry point through the renamed `_load_main`
- keep the `_resolve_main` compatibility helper delegating to `_load_main()` so imports do not fail

## Testing
- python - <<'PY'
import importlib.util
import pathlib
import sys

sys.path = [p for p in sys.path if "src" not in p]

spec = importlib.util.spec_from_file_location(
    "legacy_enrich", pathlib.Path("tools/enrich_inventory_with_ai.py").resolve()
)
module = importlib.util.module_from_spec(spec)
spec.loader.exec_module(module)

main = module.main
print(main.__module__)
main2 = module._resolve_main()
print(main2.__module__)
PY

------
https://chatgpt.com/codex/tasks/task_e_68ecc2f12668832aa5a7b176873ca2b0