### PR TITLE
Fix legacy shim main resolver call

### DIFF
--- a/tools/enrich_inventory_with_ai.py
+++ b/tools/enrich_inventory_with_ai.py
@@ -82,8 +82,7 @@ def _load_main() -> _MainCallable:
 # Resolve the CLI entry point at import time using the new ``_load_main`` helper
 # so importing this module no longer references the removed ``_resolve_main``
 # symbol and therefore avoids a ``NameError`` during import.
-main: Final[_MainCallable]
-main = _load_main()
+main: Final[_MainCallable] = _load_main()
 
 
 # Keep a compatibility helper for callers that previously imported `_resolve_main`.


### PR DESCRIPTION
## Summary
- extract the AI enrichment logic into a reusable `discos_analisis` Python package with dedicated modules
- provide a modern CLI entry point and packaging metadata via `pyproject.toml`
- keep the legacy `tools/enrich_inventory_with_ai.py` script as a thin shim for backwards compatibility
- ensure the legacy shim injects the repository `src` directory into `sys.path` before importing the CLI module so it runs from a fresh checkout
- update the shim's module-level `main` binding to call `_load_main()` so imports no longer reference the removed `_resolve_main` helper

## Testing
- python - <<'PY'
import importlib.util
import pathlib
import sys

sys.path = [p for p in sys.path if "src" not in p]

spec = importlib.util.spec_from_file_location(
    "legacy_enrich", pathlib.Path("tools/enrich_inventory_with_ai.py").resolve()
)
module = importlib.util.module_from_spec(spec)
spec.loader.exec_module(module)

main = module.main
print(main.__module__)
PY

------
https://chatgpt.com/codex/tasks/task_e_68ecc52838dc832aac0a7449e0cd3e8d